### PR TITLE
maxLengthFix

### DIFF
--- a/src/components/Inputs/CustomTextField.js
+++ b/src/components/Inputs/CustomTextField.js
@@ -17,7 +17,7 @@ const CustomTextField = ({
   autoComplete = 'off',
   numberField = false,
   editMode = false,
-  maxLength = '',
+  maxLength = '1000',
   position,
   dir='ltr',
   hidden = false,


### PR DESCRIPTION
When text field's type is number and no maxLength is sent, by default max length is '' which causes entering in condition (field's data length> maxLength) and truncating all the field's data so it is empty.
To solve the bug in profession Risk Factor field this change was done.