### PR TITLE
REM 341 fix

### DIFF
--- a/src/resources/ResourceIds.js
+++ b/src/resources/ResourceIds.js
@@ -164,7 +164,7 @@ export const ResourceIds = {
   RebuildAccountBalances: 31501,
   RoleCategories: 21102,
   SourceOfIncomeType: 36311,
-  ProfessionGroups: 36310,
+  ProfessionGroups: 36121,
   ChangePassword: 20118,
   PaymentVouchers: 31305,
   Roles: 21103,


### PR DESCRIPTION
page: profession-groups

1- add a new record, click info button is it should show record and not empty

2- test adding a duplicate name and ref it should not allow you