### PR TITLE
REM-501

### DIFF
--- a/src/pages/correspondent/Forms/CorrespondentForm.js
+++ b/src/pages/correspondent/Forms/CorrespondentForm.js
@@ -70,7 +70,7 @@ const CorrespondentForm = ({ labels, editMode, maxAccess, setEditMode, setStore,
             recordId: res.recordId
           }))
           toast.success(platformLabels.Added)
-
+          getCorrespondentById(res.recordId)
           formik.setFieldValue('recordId', res.recordId)
         } else {
           toast.success(platformLabels.Edited)


### PR DESCRIPTION
after saving a new correspondent, request the get request again because some data are generated automatically by the system and we need to fill them in the form after saving 
page: 'correspondent'