### PR TITLE
REM-444

### DIFF
--- a/src/pages/fi-payment-vouchers/forms/FiPaymentVouchersForm.js
+++ b/src/pages/fi-payment-vouchers/forms/FiPaymentVouchersForm.js
@@ -63,7 +63,7 @@ export default function FiPaymentVouchersForm({ labels, maxAccess: access, recor
       dtId: documentType?.dtId,
       status: 1,
       releaseStatus: null,
-      plantId: plantId,
+      plantId: parseInt(plantId),
       contactId: null,
       isVerified: false,
       sourceReference: ''

--- a/src/pages/fi-payment-vouchers/index.js
+++ b/src/pages/fi-payment-vouchers/index.js
@@ -169,15 +169,8 @@ const FiPaymentVouchers = () => {
   async function openForm(recordId) {
     try {
       const plantId = await getPlantId()
-      if (plantId !== '') {
-        openOutWardsWindow(plantId, recordId)
-      } else {
-        if (plantId === '') {
-          stackError({
-            message: `The user does not have a default plant.`
-          })
-        }
-      }
+      openOutWardsWindow(plantId, recordId)
+      
     } catch (error) {}
   }
 


### PR DESCRIPTION
don’t check for default user’s plantId to open the popup
we need it to set the default plantId in the field
page: 'fi-payment-vouchers'