### PR TITLE
REM-571

### DIFF
--- a/src/pages/cash-transfer/index.js
+++ b/src/pages/cash-transfer/index.js
@@ -98,6 +98,8 @@ const CashTransfer = () => {
 
     if (plantId !== '' && cashAccountId !== '') {
       openCashTransferWindow(plantId, cashAccountId, recordId, dtId)
+    } else if (recordId) {
+      openCashTransferWindow(plantId, cashAccountId, recordId, dtId)
     } else {
       if (plantId === '') {
         stackError({


### PR DESCRIPTION
fixing open form according to new and edit mode
in cash transfer we should not check for the user’s default plant or cash account

only in new mode
page: 'cash-transfer'