### PR TITLE
fix date shift problem

### DIFF
--- a/src/lib/date-helper.js
+++ b/src/lib/date-helper.js
@@ -1,6 +1,9 @@
 // import moment from 'moment';
 import { format } from 'date-fns'
 
+/**
+ * @deprecated this was removed because we need to send same date time even if different that asp
+ */
 function timeStamptoDate(timestamp) {
   const timezoneOffset = -new Date().getTimezoneOffset()
   const sign = timezoneOffset >= 0 ? '+' : '-'
@@ -16,6 +19,9 @@ function timeStamptoDate(timestamp) {
   return dateWithTimezone
 }
 
+/**
+ * @deprecated this was removed because we need to send same date time even if different that asp
+ */
 function dateToTimeStamp(date) {
   let timezoneOffset = new Date().getTimezoneOffset()
 
@@ -36,7 +42,8 @@ function dateToTimeStamp(date) {
 const formatDateFromApi = date => {
   const timestamp = date && parseInt(date.match(/-?\d+/)[0], 10)
 
-  return timestamp ? timeStamptoDate(timestamp) : null
+  //return timestamp ? timeStamptoDate(timestamp) : null
+  return timestamp ? new Date(timestamp) : null
 }
 
 /**
@@ -51,12 +58,13 @@ const formatDateFromApiInline = date => {
 }
 
 const formatDateToApi = date => {
-  const timestamp = date && dateToTimeStamp(new Date(date)).valueOf()
+  //const timestamp = date && dateToTimeStamp(new Date(date)).valueOf()
+  const timestamp = date && date.valueOf()
 
   return `/Date(${timestamp})/`
 }
 
-//should be edited??
+//should be edited by Omar
 const formatDateToApiFunction = value => {
   var date = value
   date = new Date(date)
@@ -80,6 +88,7 @@ const formatDateToApiFunction = value => {
 }
 
 function formatDateDefault(date) {
+  //used for report params
   return formatDateandTime(date)
 }
 
@@ -91,7 +100,9 @@ function formatDateandTime(date, recFormat) {
   ]
   formats = recFormat ? `${formats} ` + recFormat : formats
   const timestamp = date instanceof Date ? date.getTime() : parseInt(date?.match(/\d+/)[0], 10)
-  const formattedDate = format(timeStamptoDate(timestamp), formats)
+
+  //const formattedDate = format(timeStamptoDate(timestamp), formats)
+  const formattedDate = format(timestamp, formats)
 
   return formattedDate
 }
@@ -100,6 +111,7 @@ function formatDateTimeDefault(date) {
   return formatDateandTime(date, 'hh:mm a')
 }
 
+//Omar
 function formatTimestampToDate(timestamp) {
   if (!timestamp) return
 
@@ -126,6 +138,7 @@ function getTimeInTimeZone(dateString, timeZone = 0) {
   return `${newHours}:${newMinutes}:${newSeconds}`
 }
 
+//Omar
 const formatDate = dateString => {
   const date = new Date(dateString)
   const timestamp = date.getTime()

--- a/src/pages/batchpost/forms/BatchPostForm.js
+++ b/src/pages/batchpost/forms/BatchPostForm.js
@@ -26,11 +26,15 @@ export default function BatchPostForm({ access }) {
 
   const today = new Date()
 
+  const newStartDate = new Date()
+  newStartDate.setMonth(0)
+  newStartDate.setDate(1)
+
   const { formik } = useForm({
     initialValues: {
-      startDate: new Date(today.getFullYear(), 0, 1),
+      startDate: newStartDate,
       endDate: today,
-      status: parseInt(status),
+      status: parseInt(status)
     },
     enableReinitialize: false,
     maxAccess: access,
@@ -75,14 +79,7 @@ export default function BatchPostForm({ access }) {
   ]
 
   return (
-    <FormShell
-      form={formik}
-      actions={actions}
-      isSaved={false}
-      editMode={true}
-      isInfo={false}
-      isCleared={false}
-    >
+    <FormShell form={formik} actions={actions} isSaved={false} editMode={true} isInfo={false} isCleared={false}>
       <VertLayout>
         <Grow>
           <Grid container spacing={4}>
@@ -122,9 +119,9 @@ export default function BatchPostForm({ access }) {
                 values={formik.values}
                 onChange={(event, newValue) => {
                   if (newValue?.recordId) {
-                    formik.setFieldValue('plantId', newValue?.recordId);
+                    formik.setFieldValue('plantId', newValue?.recordId)
                   } else {
-                    delete formik?.values?.plantId;
+                    delete formik?.values?.plantId
                   }
                 }}
                 error={formik.touched.plantId && Boolean(formik.errors.plantId)}

--- a/src/pages/materials-adjustment/index.js
+++ b/src/pages/materials-adjustment/index.js
@@ -61,18 +61,7 @@ const MaterialsAdjustment = () => {
       field: 'date',
       headerName: _labels[3],
       flex: 1,
-      valueFormatter: params => {
-        const dateString = params.value
-        const timestamp = parseInt(dateString.match(/\d+/)[0], 10)
-
-        if (!isNaN(timestamp)) {
-          const formattedDate = new Date(timestamp).toLocaleDateString('en-GB')
-
-          return formattedDate
-        } else {
-          return 'Invalid Date'
-        }
-      }
+      type: 'date'
     },
     {
       field: 'siteRef',


### PR DESCRIPTION
we had previously in outbound screen -where time is attached to date and sent to api then cracked and displayed in popup- a problem in time where this leads to changes in date helper file

now another changes were made to keep this behaving properly
and to solve another appearing problem of choosing a date then getting on display day before or after in activities

for testing you can try in outbound, general journals, edit client.. and any other activities
we need please also to test dates in params selections