### PR TITLE
REM-628

### DIFF
--- a/src/pages/ct-exchange-rates/index.js
+++ b/src/pages/ct-exchange-rates/index.js
@@ -105,9 +105,17 @@ const CTExchangeRates = () => {
         .array()
         .of(
           yup.object().shape({
-            minRate: yup.string().required(),
+            minRate: yup.string().required().test('min-rate-check', function (value) {
+              const { rate, minRate } = this?.parent
+
+              return minRate <= rate;
+            }),
             maxRate: yup.string().required(),
-            rate: yup.string().required(),
+            rate: yup.string().required().test('rate-max-check', function (value) {
+              const { rate, maxRate } = this?.parent
+
+              return rate <= maxRate;
+            }),
             rateCalcMethodName: yup.string().required()
           })
         )
@@ -134,6 +142,8 @@ const CTExchangeRates = () => {
       await postExchangeMaps(values, formik.values.currencyId, formik.values.raCurrencyId, formik.values.puRateTypeId)
     }
   })
+  
+  console.log(puFormik)
 
   const { formik: saFormik } = useForm({
     maxAccess: access,
@@ -144,9 +154,17 @@ const CTExchangeRates = () => {
         .array()
         .of(
           yup.object().shape({
-            minRate: yup.string().required(),
+            minRate: yup.string().required().test('min-rate-check', 'Min rate must be less than or equal to rate', function (value) {
+              const { rate, minRate } = this.parent
+
+              return minRate <= rate;
+            }),
             maxRate: yup.string().required(),
-            rate: yup.string().required(),
+            rate: yup.string().required().test('rate-max-check', 'Rate must be less than or equal to max rate', function (value) {
+              const { rate, maxRate } = this.parent
+
+              return rate <= maxRate;
+            }),
             rateCalcMethodName: yup.string().required()
           })
         )

--- a/src/pages/ct-exchange-rates/index.js
+++ b/src/pages/ct-exchange-rates/index.js
@@ -105,13 +105,13 @@ const CTExchangeRates = () => {
         .array()
         .of(
           yup.object().shape({
-            minRate: yup.string().required().test('min-rate-check', function (value) {
+            minRate: yup.string().required().test('min-rate-check', function () {
               const { rate, minRate } = this?.parent
 
               return minRate <= rate;
             }),
             maxRate: yup.string().required(),
-            rate: yup.string().required().test('rate-max-check', function (value) {
+            rate: yup.string().required().test('rate-max-check', function () {
               const { rate, maxRate } = this?.parent
 
               return rate <= maxRate;

--- a/src/pages/ct-exchange-rates/index.js
+++ b/src/pages/ct-exchange-rates/index.js
@@ -82,12 +82,18 @@ const CTExchangeRates = () => {
     {
       component: 'textfield',
       label: labels.min,
-      name: 'minRate'
+      name: 'minRate',
+      props: {
+        maxLength: formik.values.rate
+      }
     },
     {
       component: 'textfield',
       label: labels.rate,
-      name: 'rate'
+      name: 'rate',
+      props: {
+        maxLength: formik.values.maxRate
+      }
     },
     {
       component: 'textfield',
@@ -105,17 +111,30 @@ const CTExchangeRates = () => {
         .array()
         .of(
           yup.object().shape({
-            minRate: yup.string().required().test('min-rate-check', function () {
-              const { rate, minRate } = this?.parent
+            minRate: yup
+              .number()
+              .required()
+              .test('min-rate-check', function (value) {
+                const { rate } = this.parent
 
-              return minRate <= rate;
-            }),
-            maxRate: yup.string().required(),
-            rate: yup.string().required().test('rate-max-check', function () {
-              const { rate, maxRate } = this?.parent
+                return value <= rate
+              }),
+            maxRate: yup
+              .number()
+              .required()
+              .test('max-rate-check', function (value) {
+                const { rate } = this.parent
 
-              return rate <= maxRate;
-            }),
+                return value >= rate
+              }),
+            rate: yup
+              .number()
+              .required()
+              .test('rate-check', function (value) {
+                const { minRate, maxRate } = this.parent
+
+                return value >= minRate && value <= maxRate
+              }),
             rateCalcMethodName: yup.string().required()
           })
         )
@@ -152,17 +171,30 @@ const CTExchangeRates = () => {
         .array()
         .of(
           yup.object().shape({
-            minRate: yup.string().required().test('min-rate-check', function () {
-              const { rate, minRate } = this.parent
+            minRate: yup
+              .number()
+              .required()
+              .test('min-rate-check', function (value) {
+                const { rate } = this.parent
 
-              return minRate <= rate;
-            }),
-            maxRate: yup.string().required(),
-            rate: yup.string().required().test('rate-max-check', function () {
-              const { rate, maxRate } = this.parent
+                return value <= rate
+              }),
+            maxRate: yup
+              .number()
+              .required()
+              .test('max-rate-check', function (value) {
+                const { rate } = this.parent
 
-              return rate <= maxRate;
-            }),
+                return value >= rate
+              }),
+            rate: yup
+              .number()
+              .required()
+              .test('rate-check', function (value) {
+                const { minRate, maxRate } = this.parent
+
+                return value >= minRate && value <= maxRate
+              }),
             rateCalcMethodName: yup.string().required()
           })
         )

--- a/src/pages/ct-exchange-rates/index.js
+++ b/src/pages/ct-exchange-rates/index.js
@@ -142,8 +142,6 @@ const CTExchangeRates = () => {
       await postExchangeMaps(values, formik.values.currencyId, formik.values.raCurrencyId, formik.values.puRateTypeId)
     }
   })
-  
-  console.log(puFormik)
 
   const { formik: saFormik } = useForm({
     maxAccess: access,
@@ -154,13 +152,13 @@ const CTExchangeRates = () => {
         .array()
         .of(
           yup.object().shape({
-            minRate: yup.string().required().test('min-rate-check', 'Min rate must be less than or equal to rate', function (value) {
+            minRate: yup.string().required().test('min-rate-check', function () {
               const { rate, minRate } = this.parent
 
               return minRate <= rate;
             }),
             maxRate: yup.string().required(),
-            rate: yup.string().required().test('rate-max-check', 'Rate must be less than or equal to max rate', function (value) {
+            rate: yup.string().required().test('rate-max-check', function () {
               const { rate, maxRate } = this.parent
 
               return rate <= maxRate;

--- a/src/pages/ct-exchange-rates/index.js
+++ b/src/pages/ct-exchange-rates/index.js
@@ -82,18 +82,12 @@ const CTExchangeRates = () => {
     {
       component: 'textfield',
       label: labels.min,
-      name: 'minRate',
-      props: {
-        maxLength: formik.values.rate
-      }
+      name: 'minRate'
     },
     {
       component: 'textfield',
       label: labels.rate,
-      name: 'rate',
-      props: {
-        maxLength: formik.values.maxRate
-      }
+      name: 'rate'
     },
     {
       component: 'textfield',


### PR DESCRIPTION
page: 'ct-exchange-rates'
we cannot save with min > rate > max

it should only allow min <= rate <= max