### PR TITLE
Rem 448 fix

### DIFF
--- a/src/pages/iv-metals/forms/MetalsForm.js
+++ b/src/pages/iv-metals/forms/MetalsForm.js
@@ -141,6 +141,7 @@ export default function MetalsForm({ labels, maxAccess, setStore, store }) {
                 label={labels.reportingPurity}
                 value={formik.values.reportingPurity}
                 maxAccess={maxAccess}
+                allowNegative={false}
                 maxLength={6}
                 decimalScale={5}
                 onChange={formik.handleChange}

--- a/src/pages/iv-metals/forms/MetalsForm.js
+++ b/src/pages/iv-metals/forms/MetalsForm.js
@@ -38,14 +38,13 @@ export default function MetalsForm({ labels, maxAccess, setStore, store }) {
         .nullable()
         .test('is-valid-purity', function (value) {
           if (value >= 0.001 && value <= 1) return true
-
           return false
         }),
       reportingPurity: yup
         .number()
         .nullable()
         .test('is-valid-reportingPurity', function (value) {
-          if (value >= 0.001 && value <= 1) return true
+          if ((!value && value !== 0) || (value >= 0.001 && value <= 1)) return true
 
           return false
         })

--- a/src/pages/iv-metals/forms/MetalsForm.js
+++ b/src/pages/iv-metals/forms/MetalsForm.js
@@ -38,6 +38,7 @@ export default function MetalsForm({ labels, maxAccess, setStore, store }) {
         .nullable()
         .test('is-valid-purity', function (value) {
           if (value >= 0.001 && value <= 1) return true
+
           return false
         }),
       reportingPurity: yup


### PR DESCRIPTION
 reporting Purity fields have minimum value = 0.001, maximum value = 1, shows only 5 decimals  and  is not mandatory