### PR TITLE
Cash invoice

### DIFF
--- a/src/providers/AuthContext.js
+++ b/src/providers/AuthContext.js
@@ -54,7 +54,7 @@ const AuthProvider = ({ children }) => {
   const fetchData = async () => {
     const matchHostname = window.location.hostname.match(/^(.+)\.softmachine\.co$/)
 
-    const accountName = matchHostname ? matchHostname[1] : 'anthonys'
+    const accountName = matchHostname ? matchHostname[1] : 'byc-deploy'
 
     try {
       const response = await axios.get(`${process.env.NEXT_PUBLIC_AuthURL}/MA.asmx/getAC?_accountName=${accountName}`)


### PR DESCRIPTION
i created a payment component that is shared and contains columns and a data grid.The Formik file contains the initial value and validation paymentGrid

cash type is not duplicate in rows 
in rt-receipt-voucher , total amount in grid  = total amount in field above(Amount)
in cash-invoice form  , total amount in  amount grid  = total lcAmount in operations grid

Only the cash type row is included in the returnAmount value; the other return amount is zero.


When a value is entered in the id number field on a cash invoice, onBlur automatically fills in other fields with the first number,  lastName id types, ...  .For example, 1999999999 or 1112223334 are autofill ID types only.