### PR TITLE
outAssignDriver

### DIFF
--- a/src/pages/outbound-assign-driver/index.js
+++ b/src/pages/outbound-assign-driver/index.js
@@ -1,0 +1,145 @@
+import { useContext, useEffect } from 'react'
+import { RequestsContext } from 'src/providers/RequestsContext'
+import { useResourceQuery } from 'src/hooks/resource'
+import { ResourceIds } from 'src/resources/ResourceIds'
+import { Grow } from 'src/components/Shared/Layouts/Grow'
+import { VertLayout } from 'src/components/Shared/Layouts/VertLayout'
+import toast from 'react-hot-toast'
+import { ControlContext } from 'src/providers/ControlContext'
+import { DeliveryRepository } from 'src/repositories/DeliveryRepository'
+import { DataGrid } from 'src/components/Shared/DataGrid'
+import FormShell from 'src/components/Shared/FormShell'
+import { useForm } from 'src/hooks/form'
+import * as yup from 'yup'
+import { formatDateFromApi } from 'src/lib/date-helper'
+
+const OutboundAssignDriver = () => {
+  const { getRequest, postRequest } = useContext(RequestsContext)
+  const { platformLabels } = useContext(ControlContext)
+
+  const { labels, access: maxAccess } = useResourceQuery({
+    datasetId: ResourceIds.OutboundAssignDriver
+  })
+
+  const { formik } = useForm({
+    maxAccess,
+    initialValues: {
+      tripList: []
+    },
+    enableReinitialize: false,
+    validateOnChange: true,
+    validationSchema: yup.object({
+      tripList: yup.array().of(
+        yup.object().shape({
+          vehicleId: yup.string().required()
+        })
+      )
+    }),
+    onSubmit: async obj => {
+      const res = await postRequest({
+        extension: DeliveryRepository.Trip.assign,
+        record: JSON.stringify({ tripList: obj.tripList })
+      })
+      toast.success(platformLabels.Edited)
+      refetchForm(res.recordId)
+    }
+  })
+
+  async function refetchForm() {
+    const res = await getRequest({
+      extension: DeliveryRepository.Trip.unassign,
+      parameters: ``
+    })
+
+    const modifiedList =
+      res?.list?.length > 0
+        ? res?.list?.map((item, index) => {
+            return {
+              ...item,
+              id: index + 1,
+              date: formatDateFromApi(item?.date)
+            }
+          })
+        : []
+    formik.setFieldValue('tripList', modifiedList)
+  }
+
+  const columns = [
+    {
+      component: 'textfield',
+      label: labels.reference,
+      name: 'reference',
+      props: {
+        readOnly: true
+      }
+    },
+    {
+      component: 'date',
+      name: 'date',
+      label: labels.date,
+      props: {
+        readOnly: true
+      }
+    },
+    {
+      component: 'resourcecombobox',
+      label: labels.vehicle,
+      name: 'vehicleId',
+      props: {
+        endpointId: DeliveryRepository.Vehicle.qry,
+        valueField: 'recordId',
+        displayField: 'name',
+        mapping: [
+          { from: 'recordId', to: 'vehicleId' },
+          { from: 'name', to: 'vehName' }
+        ]
+      }
+    },
+    {
+      component: 'resourcecombobox',
+      label: labels.driver,
+      name: 'driverId',
+      props: {
+        endpointId: DeliveryRepository.Driver.qry,
+        valueField: 'recordId',
+        displayField: 'name',
+        mapping: [
+          { from: 'recordId', to: 'driverId' },
+          { from: 'name', to: 'driverName' }
+        ]
+      }
+    },
+    {
+      component: 'textfield',
+      label: labels.notes,
+      name: 'notes',
+      props: {
+        readOnly: true
+      }
+    }
+  ]
+
+  useEffect(() => {
+    refetchForm()
+  }, [])
+
+  return (
+    <FormShell form={formik} infoVisible={false} visibleClear={false} isCleared={false} isSavedClear={false}>
+      <VertLayout>
+        <Grow>
+          <DataGrid
+            onChange={value => formik.setFieldValue('tripList', value)}
+            value={formik.values.tripList}
+            error={formik.errors.tripList}
+            columns={columns}
+            name='tripList'
+            allowDelete={false}
+            allowAddNewLine={false}
+          />
+        </Grow>
+      </VertLayout>
+    </FormShell>
+  )
+}
+
+export default OutboundAssignDriver

--- a/src/pages/outbound-transportation/forms/OutboundTranspForm.js
+++ b/src/pages/outbound-transportation/forms/OutboundTranspForm.js
@@ -45,7 +45,7 @@ export default function OutboundTranspForm({ labels, maxAccess: access, recordId
       if (userKeys.includes(key)) {
         acc[key] = value ? parseInt(value) : null
       }
-      
+
       return acc
     }, {})
 
@@ -80,15 +80,17 @@ export default function OutboundTranspForm({ labels, maxAccess: access, recordId
       capacityVolume: null,
       wip: 1,
       wipName: '',
-      orders: [{
-        id: 1,
-        soRef: null,
-        soId: null,
-        soDate: null,
-        clientName: null,
-        soVolume: null,
-        soWipStatusName: null
-      }]
+      orders: [
+        {
+          id: 1,
+          soRef: null,
+          soId: null,
+          soDate: null,
+          clientName: null,
+          soVolume: null,
+          soWipStatusName: null
+        }
+      ]
     },
     maxAccess,
     enableReinitialize: false,
@@ -96,8 +98,7 @@ export default function OutboundTranspForm({ labels, maxAccess: access, recordId
     validationSchema: yup.object({
       departureTime: yup.string().required(),
       plantId: yup.number().required(),
-      vehicleId: yup.string().required(),
-      driverId: yup.string().required()
+      vehicleId: yup.string().required()
     }),
     onSubmit: async obj => {
       const copy = { ...obj }
@@ -319,7 +320,6 @@ export default function OutboundTranspForm({ labels, maxAccess: access, recordId
     }
   ]
 
-
   const columns = [
     {
       component: 'resourcelookup',
@@ -510,7 +510,6 @@ export default function OutboundTranspForm({ labels, maxAccess: access, recordId
                       formik.setFieldValue('driverId', newValue ? newValue?.recordId : '')
                     }}
                     error={formik.touched.driverId && Boolean(formik.errors.driverId)}
-                    required
                   />
                 </Grid>
               </Grid>

--- a/src/repositories/DeliveryRepository.js
+++ b/src/repositories/DeliveryRepository.js
@@ -27,6 +27,8 @@ export const DeliveryRepository = {
     unpost: service + 'unpostTRP',
     close: service + 'closeTRP',
     generate: service + 'generateTRP',
+    assign: service + 'assignTRP',
+    unassign: service + 'unassignedTRP'
   },
   TripOrderPack2: {
     set2: service + 'set2TRO'

--- a/src/resources/ResourceIds.js
+++ b/src/resources/ResourceIds.js
@@ -342,4 +342,5 @@ export const ResourceIds = {
   RetailInvoiceReturn: 54301,
   RetailPurchase: 54302,
   GenerateTrip: 52308,
+  OutboundAssignDriver: 52313
 }


### PR DESCRIPTION
Add a new screen titled "Assign Outbound Driver". This screen will display only outbound transportations that are closed and have no assigned driver. You are able to assign a driver, update the vehicle if needed, and save the changes.