### PR TITLE
decimalIssue

### DIFF
--- a/src/components/Shared/DataGrid/components/numberfield/edit.js
+++ b/src/components/Shared/DataGrid/components/numberfield/edit.js
@@ -1,34 +1,54 @@
+import { useContext, useRef } from 'react'
 import CustomNumberField from 'src/components/Inputs/CustomNumberField'
+import { ControlContext } from 'src/providers/ControlContext'
+import { SystemChecks } from 'src/resources/SystemChecks'
 
 export default function NumberfieldEdit({ id, column: { props, field }, value, update, updateRow }) {
+  const { systemChecks } = useContext(ControlContext)
+  const viewDecimals = systemChecks.some(check => check.checkId === SystemChecks.HIDE_LEADING_ZERO_DECIMALS)
   const isPercentIcon = props?.gridData ? props?.gridData[id - 1]?.mdType === 1 : false
+  const typing = useRef(false)
 
   const handleIconClick = () => {
     props?.iconsClicked(id, updateRow)
   }
 
+  const formatValue = val => {
+    if (!val) return ''
+    if (isNaN(val)) return val
+
+    return String(val)
+      .replace(/\.0+$/, '')
+      .replace(/(\.\d*?[1-9])0+$/, '$1')
+  }
+
   return (
     <CustomNumberField
-      value={value?.[field]}
+      value={viewDecimals ? (typing.current ? value?.[field] : formatValue(value?.[field])) : value?.[field]}
       label={''}
       readOnly={props?.readOnly}
       decimalScale={props?.decimalScale}
       autoFocus
       hasBorder={false}
       onChange={e => {
+        typing.current = true
         update({
           id,
           field,
-          value: e.target.value ? e.target.value : ''
+          value: e.target.value
         })
       }}
-      onClear={() =>
+      onClear={() => {
+        typing.current = false
         update({
           id,
           field,
           value: ''
         })
-      }
+      }}
+      onMouseLeave={() => {
+        typing.current = false
+      }}
       handleButtonClick={handleIconClick}
       isPercentIcon={isPercentIcon}
       {...props}

--- a/src/components/Shared/DataGrid/index.js
+++ b/src/components/Shared/DataGrid/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useContext, useEffect, useRef, useState } from 'react'
 import { AgGridReact } from 'ag-grid-react'
 import { Box, IconButton } from '@mui/material'
 import components from './components'
@@ -9,6 +9,8 @@ import { GridDeleteIcon } from '@mui/x-data-grid'
 import { DISABLED, FORCE_ENABLED, HIDDEN, MANDATORY, accessLevel } from 'src/services/api/maxAccess'
 import { useWindow } from 'src/windows'
 import DeleteDialog from '../DeleteDialog'
+import { ControlContext } from 'src/providers/ControlContext'
+import { SystemChecks } from 'src/resources/SystemChecks'
 
 export function DataGrid({
   name, // maxAccess
@@ -26,6 +28,8 @@ export function DataGrid({
   bg
 }) {
   const gridApiRef = useRef(null)
+  const { systemChecks } = useContext(ControlContext)
+  const viewDecimals = systemChecks.some(check => check.checkId === SystemChecks.HIDE_LEADING_ZERO_DECIMALS)
 
   const { stack } = useWindow()
 
@@ -307,6 +311,13 @@ export function DataGrid({
       process(params, oldRow, setData)
     }
 
+    const formatNumber = value => {
+      return !value ? '' : parseFloat(value).toString()
+    }
+
+    const formattedValue =
+      viewDecimals && column.colDef.component === 'numberfield' ? formatNumber(params.value) : params.value
+
     return (
       <Box
         sx={{
@@ -321,7 +332,7 @@ export function DataGrid({
             'center'
         }}
       >
-        <Component {...params} column={column.colDef} updateRow={updateRow} update={update} />
+        <Component {...params} value={formattedValue} column={column.colDef} updateRow={updateRow} update={update} />
       </Box>
     )
   }

--- a/src/pages/sales-order/Tabs/SalesOrderForm.js
+++ b/src/pages/sales-order/Tabs/SalesOrderForm.js
@@ -443,6 +443,9 @@ export default function SalesOrderForm({ labels, access, recordId, currency, win
       label: labels.unitPrice,
       name: 'unitPrice',
       updateOn: 'blur',
+      props: {
+        decimalScale: 5
+      },
       async onChange({ row: { update, newRow } }) {
         getItemPriceRow(update, newRow, DIRTYFIELD_UNIT_PRICE)
       }

--- a/src/resources/SystemChecks.js
+++ b/src/resources/SystemChecks.js
@@ -7,6 +7,7 @@ export const SystemChecks = {
   ALLOW_NAME_DUPLICATE: Module.System * 100 + 3,
   ALLOW_NO_CHILD_DATA: Module.System * 100 + 4,
   ALLOW_DOCUMENT_UNPOSTING: Module.System * 100 + 5,
+  HIDE_LEADING_ZERO_DECIMALS: Module.System * 100 + 9,
 
   // limit data access
   LIMIT_DATA_ACCESS_SYSTEM_PLANT: Module.System * 100 + 50,


### PR DESCRIPTION
The aim of this change to remove all extra zeros after decimal in datagrid numberfield.
We add new system check "hide leading zeros decimals", if it's checked all zeros should be hidden otherwise view them normally.
example: 2455.56000 will be 2455.56
                3744.000 will be 3744
                864.02 still the same 864.02