### PR TITLE
liveFixes

### DIFF
--- a/src/pages/physical-count-item/index.js
+++ b/src/pages/physical-count-item/index.js
@@ -70,8 +70,7 @@ const PhysicalCountItem = () => {
 
     formik.setFieldValue('totalCostPrice', sumCost)
     formik.setFieldValue('totalWeight', sumWeight)
-
-    setData(res ?? { list: [] })
+    setData(res || { list: [] })
 
     handleClick(res.list)
   }
@@ -263,7 +262,6 @@ const PhysicalCountItem = () => {
             columns={columns}
             gridData={data ?? { list: [] }}
             rowId={['recordId']}
-            setData={setData}
             isLoading={false}
             pageSize={50}
             refetch={refetch}

--- a/src/pages/sales-order/Tabs/SalesOrderForm.js
+++ b/src/pages/sales-order/Tabs/SalesOrderForm.js
@@ -1401,7 +1401,7 @@ export default function SalesOrderForm({ labels, access, recordId, currency, win
                 form={formik}
                 required
                 readOnly={isClosed}
-                displayFieldWidth={2}
+                displayFieldWidth={6}
                 valueShow='clientRef'
                 secondValueShow='clientName'
                 maxAccess={maxAccess}

--- a/src/pages/sc-cycle-counts/index.js
+++ b/src/pages/sc-cycle-counts/index.js
@@ -13,13 +13,11 @@ import { SCRepository } from 'src/repositories/SCRepository'
 import CycleCountsWindow from './Windows/CycleCountsWindow'
 import { useDocumentTypeProxy } from 'src/hooks/documentReferenceBehaviors'
 import { SystemFunction } from 'src/resources/SystemFunction'
-import { SystemRepository } from 'src/repositories/SystemRepository'
-import { getStorageData } from 'src/storage/storage'
 import RPBGridToolbar from 'src/components/Shared/RPBGridToolbar'
 
 const CycleCounts = () => {
   const { getRequest, postRequest } = useContext(RequestsContext)
-  const { platformLabels } = useContext(ControlContext)
+  const { platformLabels, userDefaultsData } = useContext(ControlContext)
 
   const { stack } = useWindow()
 
@@ -125,17 +123,6 @@ const CycleCounts = () => {
     await proxyAction()
   }
 
-  const userId = getStorageData('userData').userId
-
-  const getPlantId = async () => {
-    const res = await getRequest({
-      extension: SystemRepository.UserDefaults.get,
-      parameters: `_userId=${userId}&_key=plantId`
-    })
-
-    return res.record.value
-  }
-
   async function openCycleCountsWindow(plantId, recordId) {
     stack({
       Component: CycleCountsWindow,
@@ -152,7 +139,7 @@ const CycleCounts = () => {
   }
 
   async function openForm(recordId) {
-    const plantId = await getPlantId()
+    const plantId = parseInt(userDefaultsData?.list?.find(obj => obj.key === 'plantId')?.value)
 
     openCycleCountsWindow(plantId, recordId)
   }


### PR DESCRIPTION
-in sales order, client dropdown should show the whole name (now column is wider)
-in physical count item, table wasn't showing data. ex: choose SC000815 and the available site
-in cycle count, when clicking on any record errors appear

