### PR TITLE
empty address

### DIFF
--- a/src/pages/sales-order/Tabs/SalesOrderForm.js
+++ b/src/pages/sales-order/Tabs/SalesOrderForm.js
@@ -1418,6 +1418,7 @@ export default function SalesOrderForm({ labels, access, recordId, currency, win
                   formik.setFieldValue('isVattable', newValue?.isSubjectToVAT || false)
                   formik.setFieldValue('maxDiscount', newValue?.maxDiscount)
                   formik.setFieldValue('taxId', newValue?.taxId)
+                  setAddress({})
                   fillClientData(newValue?.recordId)
                 }}
                 errorCheck={'clientId'}


### PR DESCRIPTION
the address form was not emptied anywhere before
so if you sabe address and keep the form opened (after save and clear or clear)
when you try to press + and add new address always it is filled
you need to save 
or to close the form then open it to be solved

now on change of client is is being emptied