### PR TITLE
blurIssue-onclear - v5.24 (APPROVED)-merged

### DIFF
--- a/src/components/Shared/DataGrid/index.js
+++ b/src/components/Shared/DataGrid/index.js
@@ -464,7 +464,7 @@ export function DataGrid({
       const oldRow = params.data
 
       const changes = {
-        [field]: value || undefined
+        [field]: value ?? column.colDef?.defaultValue ?? ''
       }
 
       setCurrentValue(changes)
@@ -694,6 +694,7 @@ export function DataGrid({
     if (lastCellStopped.current == cellId) return
     lastCellStopped.current = cellId
     const { data, colDef } = params
+
     if (colDef.updateOn === 'blur' && data[colDef?.field] !== value[params?.columnIndex]?.[colDef?.field]) {
       if (colDef?.disableDuplicate && checkDuplicates(colDef?.field, data) && !isDup.current) {
         stackDuplicate(params)


### PR DESCRIPTION
In datagrid if a number field column has an onBlur event, attempting to clear the field or click cancel doesn't work, the old value remains stored in formik