### PR TITLE
Multi-trip (v5.24)

### DIFF
--- a/src/pages/de-gen-trip2/index.js
+++ b/src/pages/de-gen-trip2/index.js
@@ -61,13 +61,11 @@ const GenerateOutboundTransportation2 = () => {
     validateOnChange: true,
     validationSchema: yup.object({
       departureDate: yup.date().required(),
-      selectedTrucks: yup
-        .array()
-        .of(
-          yup.object().shape({
-            overloadMargins: yup.number().min(0).max(100)
-          })
-        )
+      selectedTrucks: yup.array().of(
+        yup.object().shape({
+          overloadMargins: yup.number().min(0).max(100)
+        })
+      )
     }),
     onSubmit: async obj => {
       const data = {
@@ -386,6 +384,9 @@ const GenerateOutboundTransportation2 = () => {
   }, [sortedZones])
 
   const onPreviewOutbounds = async szIds => {
+    if (formik.errors?.selectedTrucks?.length > 0) {
+      return
+    }
     const volumes = formik.values.selectedTrucks?.map(truck => truck.volume).join(',')
     const overloads = formik.values.selectedTrucks?.map(truck => truck?.overloadMargins || 0).join(',')
 
@@ -693,7 +694,6 @@ const GenerateOutboundTransportation2 = () => {
         </Grow>
         <Fixed>
           <Grid container spacing={2} mt={2}>
-            <Grid item xs={8.75}></Grid>
             <Grid item xs={0.65}>
               <CustomButton
                 onClick={() => resetForm()}
@@ -705,6 +705,16 @@ const GenerateOutboundTransportation2 = () => {
             </Grid>
             <Grid item xs={0.65}>
               <CustomButton
+                onClick={handleImport}
+                label={platformLabels.import}
+                tooltipText={platformLabels.import}
+                color='#231f20'
+                image={'import.png'}
+              />
+            </Grid>
+            <Grid item xs={8.75}></Grid>
+            <Grid item xs={0.65}>
+              <CustomButton
                 onClick={openForm}
                 tooltipText={labels.unallocatedOrders}
                 label={labels.unallocatedOrders}
@@ -714,15 +724,6 @@ const GenerateOutboundTransportation2 = () => {
               />
             </Grid>
 
-            <Grid item xs={0.65}>
-              <CustomButton
-                onClick={handleImport}
-                label={platformLabels.import}
-                tooltipText={platformLabels.import}
-                color='#231f20'
-                image={'import.png'}
-              />
-            </Grid>
             <Grid item xs={0.65}>
               <CustomButton
                 onClick={() => onPreviewOutbounds(sortedZoneIds)}

--- a/src/pages/de-gen-trip2/index.js
+++ b/src/pages/de-gen-trip2/index.js
@@ -744,7 +744,8 @@ const GenerateOutboundTransportation2 = () => {
                 color='#231f20'
                 tooltipText={platformLabels.Generate}
                 image={'generate.png'}
-                disabled={balance + 0.1 * totalTrucksVolume < 0}
+
+                //disabled={balance + 0.1 * totalTrucksVolume < 0}
               />
             </Grid>
           </Grid>


### PR DESCRIPTION
fixing bugs de-gen-trip2
1- select 2 sales zone, import them, both went down to the next area it’s correct. then search any sales zone selected again and click import, it erase the first 

2- clear the table should be clear alongside the sales zone selected and should not call the api volZO with szIds 0
3- returning the volume to numberfield and adding overload column onPreview to send it as 0 if there is no value