### PR TITLE
bugs drafts

### DIFF
--- a/src/providers/AuthContext.js
+++ b/src/providers/AuthContext.js
@@ -54,7 +54,7 @@ const AuthProvider = ({ children }) => {
   const fetchData = async () => {
     const matchHostname = window.location.hostname.match(/^(.+)\.softmachine\.co$/)
 
-    const accountName = matchHostname ? matchHostname[1] : 'cil3'
+    const accountName = matchHostname ? matchHostname[1] : 'neg-deploy'
 
     try {
       const response = await axios.get(`${process.env.NEXT_PUBLIC_AuthURL}/MA.asmx/getAC?_accountName=${accountName}`)


### PR DESCRIPTION
- changing design of draft serial return
- in draft return and invoice when serial grid is empty we should disable close button
- in draft transfer to site in edit mode was not filled causing the grid to be disabled
- in all drafts the totals before were calculated on import and edit mode, now changes were made to get the api numbers and bind them (note: in other scenario like adding serial by hand it should be calculated).. make sure to test as much scenarios as possible

possible serials that can help in site 8501
2514017413
2514015716
2514015728
2514006807
2514005815

for more demonstration of bug you can check my drafts tasks cards in review in the sprint
