### PR TITLE
Fix look up bug

### DIFF
--- a/src/components/Inputs/CustomLookup.js
+++ b/src/components/Inputs/CustomLookup.js
@@ -111,8 +111,7 @@ const CustomLookup = ({
             return typeof option === 'object' ? `${option[valueField] ? option[valueField] : ''}` : option
           }}
           onChange={(event, newValue) => {
-            
-            //setInputValue(newValue?.[valueField] || '')
+            setInputValue(newValue ? newValue[valueField] : '')
 
             onChange(name, newValue)
             setAutoFocus(true)
@@ -234,7 +233,7 @@ const CustomLookup = ({
               required={_required}
               onKeyUp={e => {
                 onKeyUp(e)
-                if (e.key !== 'Enter') e.target?.value?.length >= minChars ? setFreeSolo(false) : setFreeSolo(true)
+                if (e.key !== 'Enter') setFreeSolo(false)
               }}
               inputProps={{
                 ...params.inputProps,

--- a/src/components/Inputs/CustomLookup.js
+++ b/src/components/Inputs/CustomLookup.js
@@ -111,7 +111,6 @@ const CustomLookup = ({
             return typeof option === 'object' ? `${option[valueField] ? option[valueField] : ''}` : option
           }}
           onChange={(event, newValue) => {
-            setInputValue(newValue ? newValue[valueField] : '')
             onChange(name, newValue)
             setAutoFocus(true)
 

--- a/src/components/Inputs/CustomLookup.js
+++ b/src/components/Inputs/CustomLookup.js
@@ -111,6 +111,9 @@ const CustomLookup = ({
             return typeof option === 'object' ? `${option[valueField] ? option[valueField] : ''}` : option
           }}
           onChange={(event, newValue) => {
+            
+            //setInputValue(newValue?.[valueField] || '')
+
             onChange(name, newValue)
             setAutoFocus(true)
 


### PR DESCRIPTION
in lookup when you enter characters less than the minChars to have suggestions then press enter an error occurred.
we changed in share component so this needs mirco testing for all lookup scenarios we know(below minChars, equal minChars with no options, case of having options, selecting by mouse tab or enter).. including in data grid and lookups that request api on selection not only set fields..
in new and edit mode..