### PR TITLE
AR-3025

### DIFF
--- a/src/pages/iv-site-management/Forms/SiteManagementForm.js
+++ b/src/pages/iv-site-management/Forms/SiteManagementForm.js
@@ -235,7 +235,7 @@ export default function SiteManagementForm({ labels, maxAccess, record }) {
       key: 'RecordRemarks',
       condition: true,
       onClick: 'onRecordRemarks',
-      disabled: false
+      disabled: !editMode
     }
   ]
 


### PR DESCRIPTION
site management
try to add resource record remarks this error appear:”Empty mandatory field masterRef”
when there is no recordId it should be disabled 