### PR TITLE
fixed sourceId

### DIFF
--- a/src/pages/pm-3d-design/forms/ThreeDDesignForm.js
+++ b/src/pages/pm-3d-design/forms/ThreeDDesignForm.js
@@ -588,7 +588,7 @@ export default function ThreeDDesignForm({ labels, access, recordId }) {
             <Grid item xs={4}>
               <ImageUpload
                 ref={imageUploadRef}
-                resourceId={ResourceIds.Items}
+                resourceId={ResourceIds.ThreeDDesign}
                 seqNo={0}
                 recordId={recordId}
                 width={300}


### PR DESCRIPTION
when i save a new 3D Design with no picture, when save was done, the screen refreshed and i got a picture of hand in picture box (i did not enter a picture, save without picture).

this is not the first time it happened with me.

page: pm-3d-design