### PR TITLE
hidden openRBP button if no paramter

### DIFF
--- a/src/components/Shared/RPBGridToolbar.js
+++ b/src/components/Shared/RPBGridToolbar.js
@@ -88,7 +88,8 @@ const RPBGridToolbar = ({
       key: 'OpenRPB',
       condition: true,
       onClick: openRPB,
-      disabled: false
+      disabled: false,
+      hidden: !reportName
     },
     {
       key: 'GO',
@@ -104,7 +105,7 @@ const RPBGridToolbar = ({
       },
       disabled: false
     }
-  ]
+  ].filter(item => !item?.hidden)
 
   return (
     <GridToolbar

--- a/src/components/Shared/ReportParameterBrowser.js
+++ b/src/components/Shared/ReportParameterBrowser.js
@@ -352,7 +352,7 @@ const ReportParameterBrowser = ({ reportName, setRpbParams, rpbParams, window })
       extension: SystemRepository.ParameterDefinition,
       parameters: parameters
     }).then(res => {
-      setParameters(res.list)
+      if (res?.list) setParameters(res.list)
     })
   }
 


### PR DESCRIPTION
in new mode when I open the tab,the mouse can be in the date field instead of amount

page example: negative stock