### PR TITLE
AR-3294 - v5.26

### DIFF
--- a/src/pages/de-gen-trip2/index.js
+++ b/src/pages/de-gen-trip2/index.js
@@ -371,12 +371,18 @@ const GenerateOutboundTransportation2 = () => {
   const handleRowDragEnd = event => {
     if (!event.api) return
 
-    let allNodes = []
-    event.api.forEachNode(node => allNodes.push(node))
+    setTimeout(() => {
+      const rowCount = event.api.getDisplayedRowCount()
+      const newOrder = []
 
-    const newOrder = allNodes.sort((a, b) => a.rowIndex - b.rowIndex).map(node => node.data)
+      for (let i = 0; i < rowCount; i++) {
+        const rowNode = event.api.getDisplayedRowAtIndex(i)
+        if (rowNode) newOrder.push(rowNode.data)
+      }
 
-    setSortedZones(newOrder)
+      setSortedZones(newOrder)
+      setSelectedSaleZones({ list: newOrder })
+    }, 0)
   }
 
   const sortedZoneIds = useMemo(() => {

--- a/src/providers/AuthContext.js
+++ b/src/providers/AuthContext.js
@@ -54,7 +54,7 @@ const AuthProvider = ({ children }) => {
   const fetchData = async () => {
     const matchHostname = window.location.hostname.match(/^(.+)\.softmachine\.co$/)
 
-    const accountName = matchHostname ? matchHostname[1] : 'anthonys'
+    const accountName = matchHostname ? matchHostname[1] : 'cil3'
 
     try {
       const response = await axios.get(`${process.env.NEXT_PUBLIC_AuthURL}/MA.asmx/getAC?_accountName=${accountName}`)


### PR DESCRIPTION
I choose first Yopougon then download it in the second windows, 

second i choose Riviera then I reshuffle, I put Riviera in the first position and Yopougon in the second position.

when I decide to choose another city, it put back as it was initially (it is keeping the initial values Yopougon , Riviera however I sheffled them to Riviera , Yopougon )

Also when I choose a sales zone and drag it to the bottom it is not allowing that