### PR TITLE
outworder fixes

### DIFF
--- a/src/pages/outwards-order/Tabs/OutwardsForm.js
+++ b/src/pages/outwards-order/Tabs/OutwardsForm.js
@@ -679,7 +679,7 @@ export default function OutwardsForm({ labels, access, recordId, plantId, userId
         },
         onProductSubmit
       },
-      width: 1100,
+      width: 1200,
       height: 500,
       title: labels.products
     })
@@ -729,7 +729,7 @@ export default function OutwardsForm({ labels, access, recordId, plantId, userId
           }
         },
         width: 740,
-        height: 320,
+        height: 345,
         title: labels.instantCash
       })
     } else if (interfaceId === 2) {
@@ -1057,7 +1057,12 @@ export default function OutwardsForm({ labels, access, recordId, plantId, userId
                             beneficiaryName: '',
                             currencyId: newValue ? header.currencyId : '',
                             lcAmount: '',
-                            fcAmount: ''
+                            fcAmount: '',
+                            corRef: '',
+                            corName: '',
+                            exRate: 1,
+                            exRate2: 1,
+                            commission: 0
                           }
                         })
                       }}
@@ -1102,7 +1107,12 @@ export default function OutwardsForm({ labels, access, recordId, plantId, userId
                             currencyId: newValue?.currencyId,
                             currencyRef: newValue?.currencyRef,
                             lcAmount: '',
-                            fcAmount: ''
+                            fcAmount: '',
+                            corRef: '',
+                            corName: '',
+                            exRate: 1,
+                            exRate2: 1,
+                            commission: 0
                           }
                         })
                       }}

--- a/src/pages/outwards-order/Tabs/OutwardsForm.js
+++ b/src/pages/outwards-order/Tabs/OutwardsForm.js
@@ -60,6 +60,7 @@ export default function OutwardsForm({ labels, access, recordId, plantId, userId
   const { maxAccess } = useDocumentType({
     functionId: SystemFunction.OutwardsOrder,
     access,
+    objectName: 'header',
     hasDT: false
   })
 
@@ -339,6 +340,7 @@ export default function OutwardsForm({ labels, access, recordId, plantId, userId
 
     const result = await refetchForm(res?.recordId)
     result?.record?.headerView?.status === 4 && openRV()
+    invalidate()
   }
 
   const onReopen = async () => {
@@ -626,7 +628,7 @@ export default function OutwardsForm({ labels, access, recordId, plantId, userId
       key: 'Receipt Voucher',
       condition: true,
       onClick: openRV,
-      disabled: !(formik.values.status == 4)
+      disabled: !(formik.values.header.status == 4)
     }
   ]
 
@@ -677,7 +679,7 @@ export default function OutwardsForm({ labels, access, recordId, plantId, userId
         },
         onProductSubmit
       },
-      width: 900,
+      width: 1100,
       height: 500,
       title: labels.products
     })

--- a/src/pages/outwards-order/Windows/ProductsWindow.js
+++ b/src/pages/outwards-order/Windows/ProductsWindow.js
@@ -85,13 +85,14 @@ const ProductsWindow = ({
     {
       field: '',
       headerName: '',
-      flex: 1,
+      flex: 0.9,
       cellRenderer: params => {
         if (params.data.interfaceId === 1)
           return (
             <Button
               variant='contained'
               size='small'
+              disabled={!!recordId}
               style={{ height: 25 }}
               onClick={() =>
                 stack({
@@ -177,6 +178,9 @@ const ProductsWindow = ({
           pagination={false}
           showCheckboxColumn={true}
           ChangeCheckedRow={setGridData}
+          disable={() => {
+            return !!recordId
+          }}
         />
       </Grow>
       <Fixed>

--- a/src/pages/outwards-order/Windows/ProductsWindow.js
+++ b/src/pages/outwards-order/Windows/ProductsWindow.js
@@ -85,7 +85,7 @@ const ProductsWindow = ({
     {
       field: '',
       headerName: '',
-      flex: 0.9,
+      flex: 0.65,
       cellRenderer: params => {
         if (params.data.interfaceId === 1)
           return (
@@ -93,7 +93,7 @@ const ProductsWindow = ({
               variant='contained'
               size='small'
               disabled={!!recordId}
-              style={{ height: 25 }}
+              style={{ height: 25, width: 40 }}
               onClick={() =>
                 stack({
                   Component: SelectAgent,
@@ -129,18 +129,19 @@ const ProductsWindow = ({
     {
       field: 'fees',
       headerName: labels.Fees,
-      flex: 1
+      flex: 0.5,
+      type: 'number'
     },
     {
       field: 'originAmount',
       headerName: labels.originAmount,
-      flex: 1,
+      flex: 0.8,
       type: { field: 'number', decimal: 2 }
     },
     {
       field: 'baseAmount',
       headerName: labels.BaseAmount,
-      flex: 1,
+      flex: 0.8,
       type: { field: 'number', decimal: 2 }
     },
     {

--- a/src/pages/outwards-order/index.js
+++ b/src/pages/outwards-order/index.js
@@ -98,6 +98,12 @@ const OutwardsOrder = () => {
       flex: 1
     },
     {
+      field: 'date',
+      headerName: _labels.date,
+      flex: 1,
+      type: 'date'
+    },
+    {
       field: 'countryRef',
       headerName: _labels.CountryRef,
       flex: 1

--- a/src/providers/AuthContext.js
+++ b/src/providers/AuthContext.js
@@ -54,7 +54,7 @@ const AuthProvider = ({ children }) => {
   const fetchData = async () => {
     const matchHostname = window.location.hostname.match(/^(.+)\.softmachine\.co$/)
 
-    const accountName = matchHostname ? matchHostname[1] : 'anthonys'
+    const accountName = matchHostname ? matchHostname[1] : 'byc-deploy'
 
     try {
       const response = await axios.get(`${process.env.NEXT_PUBLIC_AuthURL}/MA.asmx/getAC?_accountName=${accountName}`)


### PR DESCRIPTION
1. reference should not be enabled in new mode because the number range is not external
2. when we close an old record, the outer grid is not reloaded
3. why is the receipt voucher button always disabled ? example OWO-0051
4. if the OWO is not editable, why the products popup checkbox column is editable ? check also for the additional button next to the agent column
5. increase the products popup width so the columns are not shrinked

for testing:

instantCash: country :AED , dispersalType: bank , currency : AE, client: EMPBYC0008, befeneficiary: omar ic

terapay : country : pkstan , dispersalType: bank , currency : pk, client: EMPBYC0008, purpose of exchange: gift, befeneficiary: aft