### PR TITLE
Ar 3428

### DIFF
--- a/src/pages/iv-items/forms/ItemProductionForm.js
+++ b/src/pages/iv-items/forms/ItemProductionForm.js
@@ -20,8 +20,6 @@ export default function ItemProductionForm({ labels, editMode, maxAccess, store 
   const { recordId, productionLevel } = store
   const { platformLabels } = useContext(ControlContext)
 
-  console.log(recordId)
-
   const { formik } = useForm({
     initialValues: {
       itemId: recordId,

--- a/src/pages/iv-items/forms/ItemProductionForm.js
+++ b/src/pages/iv-items/forms/ItemProductionForm.js
@@ -20,8 +20,6 @@ export default function ItemProductionForm({ labels, editMode, maxAccess, store 
   const { recordId, productionLevel } = store
   const { platformLabels } = useContext(ControlContext)
 
-  console.log(store)
-
   const { formik } = useForm({
     initialValues: {
       itemId: store.recordId,
@@ -260,7 +258,7 @@ export default function ItemProductionForm({ labels, editMode, maxAccess, store 
                 valueShow='wipItemSku'
                 secondValueShow='wipItemName'
                 form={formik}
-                readOnly={store.productionLevel != 4}
+                readOnly={productionLevel != 4}
                 onChange={(_, newValue) => {
                   formik.setFieldValue('wipItemSku', newValue?.sku || null)
                   formik.setFieldValue('wipItemName', newValue?.name || '')

--- a/src/pages/iv-items/forms/ItemProductionForm.js
+++ b/src/pages/iv-items/forms/ItemProductionForm.js
@@ -17,8 +17,10 @@ import { ControlContext } from 'src/providers/ControlContext'
 
 export default function ItemProductionForm({ labels, editMode, maxAccess, store }) {
   const { getRequest, postRequest } = useContext(RequestsContext)
-  const { recordId } = store
+  const { recordId, productionLevel } = store
   const { platformLabels } = useContext(ControlContext)
+
+  console.log(store)
 
   const { formik } = useForm({
     initialValues: {
@@ -34,10 +36,12 @@ export default function ItemProductionForm({ labels, editMode, maxAccess, store 
       standardId: '',
       cgId: '',
       rmcId: '',
-      bomId: null
+      bomId: null,
+      wipItemId: null,
+      wipItemSku: '',
+      wipItemName: ''
     },
     maxAccess,
-    enableReinitialize: true,
     validateOnChange: true,
     onSubmit: async obj => {
       await postRequest({
@@ -84,7 +88,7 @@ export default function ItemProductionForm({ labels, editMode, maxAccess, store 
     >
       <VertLayout>
         <Grow>
-          <Grid container spacing={4}>
+          <Grid container spacing={2}>
             <Grid item xs={12}>
               <ResourceComboBox
                 endpointId={ManufacturingRepository.ProductionLine.qry}
@@ -244,6 +248,26 @@ export default function ItemProductionForm({ labels, editMode, maxAccess, store 
                 onChange={(event, newValue) => {
                   formik.setFieldValue('bomId', newValue?.recordId || '')
                 }}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <ResourceLookup
+                endpointId={InventoryRepository.Item.snapshot}
+                name='wipItemId'
+                label={labels.wipItem}
+                valueField='sku'
+                displayField='name'
+                valueShow='wipItemSku'
+                secondValueShow='wipItemName'
+                form={formik}
+                readOnly={store.productionLevel != 4}
+                onChange={(_, newValue) => {
+                  formik.setFieldValue('wipItemSku', newValue?.sku || null)
+                  formik.setFieldValue('wipItemName', newValue?.name || '')
+                  formik.setFieldValue('wipItemId', newValue?.recordId || '')
+                }}
+                error={formik.touched.wipItemId && Boolean(formik.errors.wipItemId)}
+                maxAccess={maxAccess}
               />
             </Grid>
           </Grid>

--- a/src/pages/iv-items/forms/ItemProductionForm.js
+++ b/src/pages/iv-items/forms/ItemProductionForm.js
@@ -20,9 +20,11 @@ export default function ItemProductionForm({ labels, editMode, maxAccess, store 
   const { recordId, productionLevel } = store
   const { platformLabels } = useContext(ControlContext)
 
+  console.log(recordId)
+
   const { formik } = useForm({
     initialValues: {
-      itemId: store.recordId,
+      itemId: recordId,
       lineId: '',
       spfId: '',
       ltId: '',
@@ -44,7 +46,10 @@ export default function ItemProductionForm({ labels, editMode, maxAccess, store 
     onSubmit: async obj => {
       await postRequest({
         extension: InventoryRepository.ItemProduction.set,
-        record: JSON.stringify(obj)
+        record: JSON.stringify({
+          ...obj,
+          itemId: recordId
+        })
       })
 
       formik.setValues(obj)
@@ -264,7 +269,7 @@ export default function ItemProductionForm({ labels, editMode, maxAccess, store 
                   formik.setFieldValue('wipItemName', newValue?.name || '')
                   formik.setFieldValue('wipItemId', newValue?.recordId || '')
                 }}
-                error={formik.touched.wipItemId && Boolean(formik.errors.wipItemId)}
+                errorCheck={'wipItemId'}
                 maxAccess={maxAccess}
               />
             </Grid>

--- a/src/pages/iv-items/forms/ItemsForm.js
+++ b/src/pages/iv-items/forms/ItemsForm.js
@@ -173,6 +173,7 @@ export default function ItemsForm({ labels, maxAccess: access, setStore, store, 
           nraId: res2?.record?.nraId,
           _msId: res.record.msId,
           _kit: res.record.kitItem,
+          productionLevel: res.record.productionLevel,
           measurementId: res.record.defSaleMUId,
           priceGroupId: res.record.pgId,
           returnPolicy: res.record.returnPolicyId,
@@ -536,6 +537,10 @@ export default function ItemsForm({ labels, maxAccess: access, setStore, store, 
                     values={formik.values}
                     onChange={(event, newValue) => {
                       formik.setFieldValue('productionLevel', newValue?.key || '')
+                      setStore(prevStore => ({
+                        ...prevStore,
+                        productionLevel: newValue?.key
+                      }))
                     }}
                     maxAccess={maxAccess}
                     error={formik.touched.productionLevel && Boolean(formik.errors.productionLevel)}

--- a/src/pages/iv-items/window/ItemWindow.js
+++ b/src/pages/iv-items/window/ItemWindow.js
@@ -27,8 +27,11 @@ const ItemWindow = ({ recordId, labels, msId, maxAccess }) => {
     _reference: null,
     _isMetal: false,
     _metal: null,
-    nraId: null
+    nraId: null,
+    productionLevel: null
   })
+
+  console.log(store)
 
   const tabs = [
     { label: labels.items },

--- a/src/pages/iv-items/window/ItemWindow.js
+++ b/src/pages/iv-items/window/ItemWindow.js
@@ -31,8 +31,6 @@ const ItemWindow = ({ recordId, labels, msId, maxAccess }) => {
     productionLevel: null
   })
 
-  console.log(store)
-
   const tabs = [
     { label: labels.items },
     { label: labels.barcode, disabled: !store.recordId },


### PR DESCRIPTION
In items screen / production tab
add wipItemId in the production tab, it’s a lookup that fills from IV.snapshotIT
the wipItemId is enabled only when production level id = 4