### PR TITLE
AR-3248

### DIFF
--- a/src/pages/iv-items/forms/ItemProductionForm.js
+++ b/src/pages/iv-items/forms/ItemProductionForm.js
@@ -253,7 +253,10 @@ export default function ItemProductionForm({ labels, editMode, maxAccess, store 
             </Grid>
             <Grid item xs={12}>
               <ResourceLookup
-                endpointId={InventoryRepository.Item.snapshot}
+                endpointId={InventoryRepository.Item.snapshot3}
+                parameters={{
+                  _productionLevel: 4
+                }}
                 name='wipItemId'
                 label={labels.wipItem}
                 valueField='sku'
@@ -261,7 +264,7 @@ export default function ItemProductionForm({ labels, editMode, maxAccess, store 
                 valueShow='wipItemSku'
                 secondValueShow='wipItemName'
                 form={formik}
-                readOnly={productionLevel != 4}
+                readOnly={productionLevel == 4}
                 onChange={(_, newValue) => {
                   formik.setFieldValue('wipItemSku', newValue?.sku || null)
                   formik.setFieldValue('wipItemName', newValue?.name || '')

--- a/src/pages/iv-items/forms/ItemsForm.js
+++ b/src/pages/iv-items/forms/ItemsForm.js
@@ -542,6 +542,7 @@ export default function ItemsForm({ labels, maxAccess: access, setStore, store, 
                         productionLevel: newValue?.key
                       }))
                     }}
+                    readOnly={editMode}
                     maxAccess={maxAccess}
                     error={formik.touched.productionLevel && Boolean(formik.errors.productionLevel)}
                   />

--- a/src/repositories/InventoryRepository.js
+++ b/src/repositories/InventoryRepository.js
@@ -8,6 +8,7 @@ export const InventoryRepository = {
   },
   Item: {
     snapshot: service + 'snapshotIT',
+    snapshot3: service + 'snapshotIT3',
     get: service + 'getIT',
     quickView: service + 'quickViewIT'
   },


### PR DESCRIPTION
in Items screen, tab Production, if production level of the item is different than Work In Process, the Work in Process lookup should be enabled (now its the opposite)

the lookup should show only items with production level Work In Process 
Disable production level in editMode