### PR TITLE
Gl number issue

### DIFF
--- a/src/components/Shared/GeneralLedger.js
+++ b/src/components/Shared/GeneralLedger.js
@@ -586,7 +586,6 @@ const GeneralLedger = ({ functionId, values, valuesPath, datasetId, onReset, win
                     dirtyField: DIRTYFIELD_RATE
                   })
                   update({
-                    exRate: updatedRateRow.exRate,
                     amount: updatedRateRow.amount,
                     baseAmount: updatedRateRow.baseAmount
                   })
@@ -609,7 +608,6 @@ const GeneralLedger = ({ functionId, values, valuesPath, datasetId, onReset, win
                   })
                   update({
                     exRate: updatedRateRow.exRate,
-                    amount: updatedRateRow.amount,
                     baseAmount: updatedRateRow.baseAmount
                   })
                 }
@@ -631,8 +629,7 @@ const GeneralLedger = ({ functionId, values, valuesPath, datasetId, onReset, win
                   })
                   update({
                     exRate: updatedRateRow.exRate,
-                    amount: updatedRateRow.amount,
-                    baseAmount: updatedRateRow.baseAmount
+                    amount: updatedRateRow.amount
                   })
                 }
               }

--- a/src/pages/return-on-invoice/forms/ReturnOnInvoiceForm.js
+++ b/src/pages/return-on-invoice/forms/ReturnOnInvoiceForm.js
@@ -539,6 +539,7 @@ export default function ReturnOnInvoiceForm({ labels, access, recordId, currency
       props: {
         decimalScale: 5
       },
+      updateOn: 'blur',
       async onChange({ row: { update, newRow } }) {
         getItemPriceRow(update, newRow, DIRTYFIELD_UNIT_PRICE)
       }
@@ -550,6 +551,7 @@ export default function ReturnOnInvoiceForm({ labels, access, recordId, currency
       props: {
         decimalScale: 5
       },
+      updateOn: 'blur',
       async onChange({ row: { update, newRow } }) {
         getItemPriceRow(update, newRow, DIRTYFIELD_BASE_PRICE)
       }

--- a/src/pages/sales-quotations/Tabs/SalesQuotationForm.js
+++ b/src/pages/sales-quotations/Tabs/SalesQuotationForm.js
@@ -375,6 +375,7 @@ export default function SalesQuotationForm({ labels, access, recordId, currency,
       component: 'numberfield',
       label: labels.quantity,
       name: 'qty',
+      updateOn: 'blur',
       onChange({ row: { update, newRow } }) {
         const data = getItemPriceRow(newRow, DIRTYFIELD_QTY)
         update(data)
@@ -408,6 +409,7 @@ export default function SalesQuotationForm({ labels, access, recordId, currency,
       props: {
         decimalScale: 5
       },
+      updateOn: 'blur',
       async onChange({ row: { update, newRow } }) {
         const data = getItemPriceRow(newRow, DIRTYFIELD_BASE_PRICE)
         update(data)
@@ -420,6 +422,7 @@ export default function SalesQuotationForm({ labels, access, recordId, currency,
       props: {
         decimalScale: 5
       },
+      updateOn: 'blur',
       async onChange({ row: { update, newRow } }) {
         const data = getItemPriceRow(newRow, DIRTYFIELD_UNIT_PRICE)
         update(data)
@@ -429,6 +432,7 @@ export default function SalesQuotationForm({ labels, access, recordId, currency,
       component: 'numberfield',
       label: labels.upo,
       name: 'upo',
+      updateOn: 'blur',
       async onChange({ row: { update, newRow } }) {
         const data = getItemPriceRow(newRow, DIRTYFIELD_UPO)
         update(data)
@@ -465,6 +469,7 @@ export default function SalesQuotationForm({ labels, access, recordId, currency,
       component: 'numberfield',
       label: labels.markdown,
       name: 'mdAmount',
+      updateOn: 'blur',
       flex: 2,
       props: {
         ShowDiscountIcons: true,
@@ -498,6 +503,7 @@ export default function SalesQuotationForm({ labels, access, recordId, currency,
       component: 'numberfield',
       label: labels.extendedprice,
       name: 'extendedPrice',
+      updateOn: 'blur',
       async onChange({ row: { update, newRow } }) {
         const data = getItemPriceRow(newRow, DIRTYFIELD_EXTENDED_PRICE)
         update(data)

--- a/src/pages/shipments/forms/ShipmentsForm.js
+++ b/src/pages/shipments/forms/ShipmentsForm.js
@@ -553,6 +553,7 @@ export default function ShipmentsForm({ labels, maxAccess: access, recordId, inv
       props: {
         readOnly: isPosted
       },
+      updateOn: 'blur',
       async onChange({ row: { update, oldRow, newRow } }) {
         checkMaximum(newRow?.shippedNowQty, newRow, update)
         if (newRow?.muQty)


### PR DESCRIPTION
There’s a bug in the dataGrid number fields in the following screens:
- General Ledger
- Return on Invoice
- Sales Quotations
- Shipments Form
When typing in the number field, it loses focus and then immediately regains it. You can check this issue on deploy.