### PR TITLE
job transfer checkout: consition based on qty

### DIFF
--- a/src/pages/job-transfer-checkout/forms/JTCheckoutForm.js
+++ b/src/pages/job-transfer-checkout/forms/JTCheckoutForm.js
@@ -129,13 +129,13 @@ export default function JTCheckoutForm({ labels, recordId, access, window }) {
     })()
   }, [])
 
-  const isPosted = formik.values.transfer.status === 3
-  const isClosed = formik.values.transfer.wip === 2
-
   const totalQty =
     formik?.values?.categorySummary != [] ? formik?.values?.categorySummary.reduce((op, item) => op + item?.qty, 0) : 0
 
   const editMode = !!formik?.values?.transfer?.recordId
+  const isPosted = formik.values.transfer.status === 3
+  const isClosed = formik.values.transfer.wip === 2
+  const isMismatch = Math.abs(totalQty - formik?.values?.transfer?.qty) > 0.05
 
   const onPost = async () => {
     await postRequest({
@@ -283,7 +283,7 @@ export default function JTCheckoutForm({ labels, recordId, access, window }) {
       editMode={editMode}
       actions={actions}
       previewReport={editMode}
-      disabledSubmit={isClosed}
+      disabledSubmit={isClosed || isMismatch}
     >
       <VertLayout>
         <Fixed>


### PR DESCRIPTION
We don’t want to let the user to be able to create (save) the transfer until the Qty and Total Qty are identical.
only variation of 0.05 is accepted.
you can choose different job orders to test the condition added on save button