### PR TITLE
AR-3376-V2 - APPROVED - LIVE

### DIFF
--- a/src/pages/iv-items/forms/ItemsForm.js
+++ b/src/pages/iv-items/forms/ItemsForm.js
@@ -20,7 +20,7 @@ import { MasterSource } from 'src/resources/MasterSource'
 import CustomCheckBox from 'src/components/Inputs/CustomCheckBox'
 import { DataSets } from 'src/resources/DataSets'
 
-export default function ItemsForm({ labels, maxAccess: access, setStore, store, setFormikInitial }) {
+export default function ItemsForm({ labels, maxAccess: access, setStore, store, setFormikInitial, window }) {
   const { platformLabels } = useContext(ControlContext)
   const [showLotCategories, setShowLotCategories] = useState(false)
   const [showSerialProfiles, setShowSerialProfiles] = useState(false)
@@ -141,6 +141,9 @@ export default function ItemsForm({ labels, maxAccess: access, setStore, store, 
       }))
 
       formik.setFieldValue('sku', res.record.sku)
+      if (window.setTitle) {
+        window.setTitle(res.record.sku ? `${labels.items} ${res.record.sku}` : labels.items)
+      }
 
       invalidate()
     }

--- a/src/pages/iv-items/window/ItemWindow.js
+++ b/src/pages/iv-items/window/ItemWindow.js
@@ -11,7 +11,7 @@ import ItemProductionForm from '../forms/ItemProductionForm.js'
 import KitForm from '../forms/KitForm.js'
 import RetailForm from '../forms/RetailForm.js'
 
-const ItemWindow = ({ recordId, labels, msId, maxAccess }) => {
+const ItemWindow = ({ recordId, labels, msId, maxAccess, window }) => {
   const [activeTab, setActiveTab] = useState(0)
   const [formikInitial, setFormikInitial] = useState([])
   const editMode = !!recordId
@@ -54,6 +54,7 @@ const ItemWindow = ({ recordId, labels, msId, maxAccess }) => {
           editMode={editMode}
           maxAccess={maxAccess}
           setFormikInitial={setFormikInitial}
+          window={window}
         />
       </CustomTabPanel>
       <CustomTabPanel index={1} value={activeTab}>

--- a/src/pages/mf-job-orders/form/JobOrderForm.js
+++ b/src/pages/mf-job-orders/form/JobOrderForm.js
@@ -39,7 +39,8 @@ export default function JobOrderForm({
   store,
   setRefetchRouting,
   invalidate,
-  lockRecord
+  lockRecord,
+  window
 }) {
   const { getRequest, postRequest } = useContext(RequestsContext)
   const { stack } = useWindow()
@@ -143,7 +144,10 @@ export default function JobOrderForm({
         ...prevStore,
         recordId: res?.recordId
       }))
-      await refetchForm(res.recordId)
+      const reference = await refetchForm(res.recordId)
+      if (window.setTitle) {
+        window.setTitle(reference ? `${labels.jobOrder} ${reference}` : labels.jobOrder)
+      }
     }
   })
   const editMode = !!formik.values.recordId
@@ -200,8 +204,7 @@ export default function JobOrderForm({
     {
       key: 'SerialsLots',
       condition: true,
-      onClick: openSerials,
-      disabled: !editMode || !formik.values.itemId || (!isReleased && formik.values.trackBy == 1)
+      onClick: openSerials
     },
     {
       key: 'Start',
@@ -390,6 +393,8 @@ export default function JobOrderForm({
         reference: res?.record.reference,
         resourceId: ResourceIds.MFJobOrders
       })
+
+    return res?.record.reference
   }
 
   async function getRouting(recordId) {

--- a/src/pages/mf-job-orders/form/RoutingTab.js
+++ b/src/pages/mf-job-orders/form/RoutingTab.js
@@ -76,6 +76,9 @@ export default function RoutingTab({ labels, maxAccess, store, refetchRouting, s
       label: labels.seqNo,
       name: 'seqNo',
       width: 65,
+      props: {
+        unClearable: true
+      },
       propsReducer({ row, props }) {
         return { ...props, readOnly: [1, 2, 3, 4].includes(row.status) }
       }

--- a/src/pages/mf-job-orders/index.js
+++ b/src/pages/mf-job-orders/index.js
@@ -163,7 +163,8 @@ const JobOrder = () => {
       },
       width: 1150,
       height: 700,
-      title: labels.jobOrder
+      title: labels.jobOrder,
+      nextToTitle: reference
     })
   }
 

--- a/src/pages/mf-job-orders/window/JobOrderWindow.js
+++ b/src/pages/mf-job-orders/window/JobOrderWindow.js
@@ -8,7 +8,7 @@ import OverheadTab from '../form/OverheadTab'
 import MaterialsTab from '../form/MaterialsTab'
 import SizesTab from '../form/SizesTab'
 
-const JobOrderWindow = ({ recordId, jobReference, access, labels, invalidate, lockRecord }) => {
+const JobOrderWindow = ({ recordId, jobReference, access, labels, invalidate, lockRecord, window }) => {
   const [activeTab, setActiveTab] = useState(0)
   const [store, setStore] = useState({ recordId, jobReference, isPosted: false, isCancelled: false })
   const [refetchRouting, setRefetchRouting] = useState(false)
@@ -34,6 +34,7 @@ const JobOrderWindow = ({ recordId, jobReference, access, labels, invalidate, lo
           setRefetchRouting={setRefetchRouting}
           invalidate={invalidate}
           lockRecord={lockRecord}
+          window={window}
         />
       </CustomTabPanel>
       <CustomTabPanel index={1} value={activeTab}>

--- a/src/windows/index.js
+++ b/src/windows/index.js
@@ -190,7 +190,7 @@ export function WindowProvider({ children }) {
                   : { access: { ...props?.access, editMode: !!props?.recordId } })}
                 window={{
                   close: () => closeWindowById(id),
-                  setTitle: newTitle => updateWindow(id, { title: title || newTitle })
+                  setTitle: newTitle => updateWindow(id, { title: newTitle || title })
                 }}
               />
             </Window>


### PR DESCRIPTION
serial lots button Serials lots is disabled, it should be always enabled.
Remove the submit and generate button from the serials lots form and the data grid should be readOnly
Job order title to have reference at the top in the form same behaviour as items screen
Remove the x in seqNo Routing tab