### PR TITLE
fixes documentid

### DIFF
--- a/src/pages/fi-cash-tfr/Forms/CashTransfersForm.js
+++ b/src/pages/fi-cash-tfr/Forms/CashTransfersForm.js
@@ -55,7 +55,7 @@ export default function CashTransfersForm({ labels, maxAccess: access, recordId 
     statusName: '',
     functionId: SystemFunction.CashTransfers,
     reference: '',
-    dtId: null,
+    dtId: documentType?.dtId,
     date: new Date(),
     status: 1,
     releaseStatus: 1,

--- a/src/pages/fi-cash-tfr/Forms/CashTransfersForm.js
+++ b/src/pages/fi-cash-tfr/Forms/CashTransfersForm.js
@@ -40,7 +40,7 @@ export default function CashTransfersForm({ labels, maxAccess: access, recordId 
   })
 
   const initialValues = {
-    recordId,
+    recordId: recordId || null,
     currencyId: parseInt(getDefaultsData()?.currencyId),
     currencyRef: '',
     currencyName: '',
@@ -55,7 +55,7 @@ export default function CashTransfersForm({ labels, maxAccess: access, recordId 
     statusName: '',
     functionId: SystemFunction.CashTransfers,
     reference: '',
-    dtId: documentType?.dtId,
+    dtId: null,
     date: new Date(),
     status: 1,
     releaseStatus: 1,
@@ -102,7 +102,7 @@ export default function CashTransfersForm({ labels, maxAccess: access, recordId 
           message: labels.errorMessage
         })
 
-        return
+        throw { silent: true }
       }
 
       const res = await postRequest({


### PR DESCRIPTION
Financials/Cash and banks/Transfers

Add a new record — the document type should be shown by default. After clicking save and clear, the document type field becomes empty. It should still display the default document type.