### PR TITLE
AR-3587 

### DIFF
--- a/src/components/Shared/FormShell.js
+++ b/src/components/Shared/FormShell.js
@@ -23,6 +23,7 @@ import StrictUnpostConfirmation from './StrictUnpostConfirmation'
 import ClientSalesTransaction from './ClientSalesTransaction'
 import AttachmentList from './AttachmentList'
 import { RequestsContext } from 'src/providers/RequestsContext'
+import { useError } from 'src/error'
 
 function LoadingOverlay() {
   return (
@@ -76,6 +77,7 @@ export default function FormShell({
   const isSavedClearVisible = isSavedClear && isSaved && isCleared
   const { loading } = useContext(RequestsContext)
   const [showOverlay, setShowOverlay] = useState(false)
+  const { stack: stackError } = useError()
 
   const windowToolbarVisible = editMode
     ? maxAccess < TrxType.EDIT
@@ -200,10 +202,15 @@ export default function FormShell({
           break
         case 'onClickGL':
           action.onClick = () => {
+            if (action.error) {
+              stackError(action.error)
+
+              return
+            }
             stack({
               Component: GeneralLedger,
               props: {
-                values: form.values,
+                values: action.values || form.values,
                 recordId: form.values?.recordId,
                 functionId: functionId,
                 valuesPath: action.valuesPath,

--- a/src/components/Shared/GeneralLedger.js
+++ b/src/components/Shared/GeneralLedger.js
@@ -142,7 +142,7 @@ const GeneralLedger = ({ functionId, values, valuesPath, datasetId, onReset, win
       if (datasetId === 42604) {
         if (!formValues.endingDT) {
           stackError({
-            message: _labels.emptyEndingDate
+            message: platformLabels.emptyEndingDate
           })
           window.close()
         }

--- a/src/components/Shared/GeneralLedger.js
+++ b/src/components/Shared/GeneralLedger.js
@@ -26,7 +26,6 @@ import { VertLayout } from './Layouts/VertLayout'
 import { useForm } from 'src/hooks/form'
 import { ControlContext } from 'src/providers/ControlContext'
 import useSetWindow from 'src/hooks/useSetWindow'
-import { useError } from 'src/error'
 
 const GeneralLedger = ({ functionId, values, valuesPath, datasetId, onReset, window }) => {
   const { getRequest, postRequest } = useContext(RequestsContext)
@@ -35,7 +34,6 @@ const GeneralLedger = ({ functionId, values, valuesPath, datasetId, onReset, win
   const [baseGridData, setBaseGridData] = useState({ credit: 0, debit: 0, balance: 0 })
   const [exRateValue, setExRateValue] = useState(null)
   const [currencyGridData, setCurrencyGridData] = useState([])
-  const { stack: stackError } = useError()
   const formValues = valuesPath ? valuesPath : values
 
   useSetWindow({ title: platformLabels.GeneralLedger, window })
@@ -65,7 +63,7 @@ const GeneralLedger = ({ functionId, values, valuesPath, datasetId, onReset, win
     initialValues: {
       recordId: formValues.recordId,
       reference: formValues.reference,
-      date: datasetId === 42604 ? formValues.endingDT : formValues.date,
+      date: formValues.date,
       functionId: functionId,
       seqNo: '',
       glTransactions: [
@@ -139,14 +137,6 @@ const GeneralLedger = ({ functionId, values, valuesPath, datasetId, onReset, win
 
   useEffect(() => {
     if (formValues) {
-      if (datasetId === 42604) {
-        if (!formValues.endingDT) {
-          stackError({
-            message: platformLabels.emptyEndingDate
-          })
-          window.close()
-        }
-      }
       setformik(formValues)
     }
   }, [formValues])
@@ -343,7 +333,7 @@ const GeneralLedger = ({ functionId, values, valuesPath, datasetId, onReset, win
                 <CustomDatePicker
                   name='date'
                   label={_labels.date}
-                  value={datasetId === 42604 ? formik.endingDT : formik.date}
+                  value={formik.date}
                   readOnly={true}
                   maxAccess={access}
                 />

--- a/src/components/Shared/GeneralLedger.js
+++ b/src/components/Shared/GeneralLedger.js
@@ -26,6 +26,7 @@ import { VertLayout } from './Layouts/VertLayout'
 import { useForm } from 'src/hooks/form'
 import { ControlContext } from 'src/providers/ControlContext'
 import useSetWindow from 'src/hooks/useSetWindow'
+import { useError } from 'src/error'
 
 const GeneralLedger = ({ functionId, values, valuesPath, datasetId, onReset, window }) => {
   const { getRequest, postRequest } = useContext(RequestsContext)
@@ -34,6 +35,7 @@ const GeneralLedger = ({ functionId, values, valuesPath, datasetId, onReset, win
   const [baseGridData, setBaseGridData] = useState({ credit: 0, debit: 0, balance: 0 })
   const [exRateValue, setExRateValue] = useState(null)
   const [currencyGridData, setCurrencyGridData] = useState([])
+  const { stack: stackError } = useError()
   const formValues = valuesPath ? valuesPath : values
 
   useSetWindow({ title: platformLabels.GeneralLedger, window })
@@ -63,7 +65,7 @@ const GeneralLedger = ({ functionId, values, valuesPath, datasetId, onReset, win
     initialValues: {
       recordId: formValues.recordId,
       reference: formValues.reference,
-      date: formValues.date,
+      date: datasetId === 42604 ? formValues.endingDT : formValues.date,
       functionId: functionId,
       seqNo: '',
       glTransactions: [
@@ -137,6 +139,14 @@ const GeneralLedger = ({ functionId, values, valuesPath, datasetId, onReset, win
 
   useEffect(() => {
     if (formValues) {
+      if (datasetId === 42604) {
+        if (!formValues.endingDT) {
+          stackError({
+            message: _labels.emptyEndingDate
+          })
+          window.close()
+        }
+      }
       setformik(formValues)
     }
   }, [formValues])
@@ -333,7 +343,7 @@ const GeneralLedger = ({ functionId, values, valuesPath, datasetId, onReset, win
                 <CustomDatePicker
                   name='date'
                   label={_labels.date}
-                  value={formik.date}
+                  value={datasetId === 42604 ? formik.endingDT : formik.date}
                   readOnly={true}
                   maxAccess={access}
                 />

--- a/src/pages/mf-job-orders/form/JobOrderForm.js
+++ b/src/pages/mf-job-orders/form/JobOrderForm.js
@@ -196,7 +196,7 @@ export default function JobOrderForm({
       onClick: 'onClickGL',
       datasetId: ResourceIds.GLMFJobOrders,
       disabled: !editMode,
-      error: !formik?.values?.endingDT ? { message: platformLabels.emptyEndingDate } : null,
+      error: !formik?.values?.endingDT ? { message: labels.emptyEndingDate } : null,
       values: { ...formik.values, date: formik?.values?.endingDT }
     },
     {

--- a/src/pages/mf-job-orders/form/JobOrderForm.js
+++ b/src/pages/mf-job-orders/form/JobOrderForm.js
@@ -195,7 +195,9 @@ export default function JobOrderForm({
       condition: true,
       onClick: 'onClickGL',
       datasetId: ResourceIds.GLMFJobOrders,
-      disabled: !editMode
+      disabled: !editMode,
+      error: !formik?.values?.endingDT ? { message: platformLabels.emptyEndingDate } : null,
+      values: { ...formik.values, date: formik?.values?.endingDT }
     },
     {
       key: 'IV',

--- a/src/providers/AuthContext.js
+++ b/src/providers/AuthContext.js
@@ -54,7 +54,7 @@ const AuthProvider = ({ children }) => {
   const fetchData = async () => {
     const matchHostname = window.location.hostname.match(/^(.+)\.softmachine\.co$/)
 
-    const accountName = matchHostname ? matchHostname[1] : 'anthonys'
+    const accountName = matchHostname ? matchHostname[1] : 'neg-deploy'
 
     try {
       const response = await axios.get(`${process.env.NEXT_PUBLIC_AuthURL}/MA.asmx/getAC?_accountName=${accountName}`)


### PR DESCRIPTION
when opening the GL popup from the job order screen, the date in the GL should be the “ending date” not the “date”

if endingDate is empty, show an error message and don’t proceed with the popup opening