### PR TITLE
AR-3707

### DIFF
--- a/src/pages/hr-time-codes/forms/TimeCodesForm.js
+++ b/src/pages/hr-time-codes/forms/TimeCodesForm.js
@@ -60,9 +60,9 @@ export default function TimeCodesForm({ labels, maxAccess, recordId, window }) {
         })
         formik.setValues({
           edId: record?.edId,
-          gracePeriod: record?.gracePeriod,
+          gracePeriod: record?.gracePeriod || null,
           edType: record?.edType,
-          timeCode: record?.timeCode,
+          timeCode: recordId,
           recordId
         })
       }


### PR DESCRIPTION
<img width="1451" height="864" alt="Untitled (4)" src="https://github.com/user-attachments/assets/59baed08-03e2-44dd-b4c0-62088b6ccda6" />
fixes error” Empty mandatory field timeCode" when getTc return null
as last 4  rows