### PR TITLE
JOB

### DIFF
--- a/src/pages/mf-job-orders/form/ItemTab.js
+++ b/src/pages/mf-job-orders/form/ItemTab.js
@@ -117,6 +117,10 @@ export default function ItemTab({ labels, maxAccess, store }) {
       props: {
         allowNegative: false,
         maxLength: 9
+      },
+      updateOn: 'blur',
+      async onChange({ row: { update, newRow } }) {
+        update({ qty: newRow?.qty || 0, extendedCost: (newRow?.qty || 0) * (newRow?.unitCost || 0) })
       }
     },
     {
@@ -188,7 +192,7 @@ export default function ItemTab({ labels, maxAccess, store }) {
       const updateItemsList = res.list.map((item, index) => ({
         ...item,
         id: index + 1,
-        extendedCost: item?.unitCost || 0 * item?.qty || 0
+        extendedCost: (item?.unitCost || 0) * (item?.qty || 0)
       }))
 
       formik.setFieldValue('items', updateItemsList)


### PR DESCRIPTION
For Job order/items tab:
1. add 2 columns readonly unitCost and extendedCost 
->unit cost is filled from the API when posting a JO
->extendedCost = unit cost * qty

2. add a totalCost field, sum of extended code