### PR TITLE
AR-4584

### DIFF
--- a/packages/shared-ui/src/components/Shared/PurchaseTransactionForm.js
+++ b/packages/shared-ui/src/components/Shared/PurchaseTransactionForm.js
@@ -1349,6 +1349,7 @@ export default function PurchaseTransactionForm({ recordId, functionId, window }
       mdType: MDTYPE_PCT,
       extendedPrice: 0,
       mdValue: 0,
+      trackBy: itemInfo?.trackBy,
       taxId: effectiveTaxId,
       taxName: effectiveTaxName,
       taxDetails: null


### PR DESCRIPTION
 when disable sku lookup is checked trackBy value stays undefined, so the serials icon is hidden even if the item is serial tracked