### PR TITLE
AR-4612

### DIFF
--- a/packages/shared-ui/src/components/Shared/Forms/SalesOrderForm.js
+++ b/packages/shared-ui/src/components/Shared/Forms/SalesOrderForm.js
@@ -144,6 +144,8 @@ const SalesOrderForm = ({ recordId, currency, window }) => {
     weight: '',
     qty: 0,
     serializedAddress: '',
+    sourceId: null,
+    sourceNo: '',
     items: [
       {
         id: 1,


### PR DESCRIPTION
Sales Order -> if sourceId is set to mandatory from global auth. it's not lighting red (this issue noticed clearly in new mode)