### PR TITLE
AR-4610

### DIFF
--- a/packages/module-manufacturing/src/pages/mf-design/Forms/DesignsForm.js
+++ b/packages/module-manufacturing/src/pages/mf-design/Forms/DesignsForm.js
@@ -159,7 +159,6 @@ export default function DesignsForm({ labels, access, store, setStore }) {
                 <Grid item xs={12}>
                   <CustomTextField
                     name='reference'
-                    readOnly={editMode}
                     label={labels.reference}
                     value={formik.values.reference}
                     onChange={formik.handleChange}

--- a/packages/module-manufacturing/src/pages/mf-design/Forms/DesignsForm.js
+++ b/packages/module-manufacturing/src/pages/mf-design/Forms/DesignsForm.js
@@ -20,7 +20,7 @@ import { ResourceLookup } from '@argus/shared-ui/src/components/Shared/ResourceL
 import ImageUpload from '@argus/shared-ui/src/components/Inputs/ImageUpload'
 import { InventoryRepository } from '@argus/repositories/src/repositories/InventoryRepository'
 import { ManufacturingRepository } from '@argus/repositories/src/repositories/ManufacturingRepository'
-import { useRefBehavior } from '@argus/shared-hooks/src/hooks/useReferenceProxy'
+import { useFieldBehavior } from '@argus/shared-hooks/src/hooks/useFieldBehaviors'
 import CustomCheckBox from '@argus/shared-ui/src/components/Inputs/CustomCheckBox'
 
 export default function DesignsForm({ labels, access, store, setStore }) {
@@ -33,10 +33,10 @@ export default function DesignsForm({ labels, access, store, setStore }) {
     endpointId: ManufacturingRepository.Design.page
   })
 
-  const { changeDT, maxAccess } = useRefBehavior({
+  const { changeDT, maxAccess } = useFieldBehavior({
     access,
-    readOnlyOnEditMode: false,
-    name: 'reference'
+    fieldName: 'reference',
+    editMode: false
   })
 
   const { formik } = useForm({
@@ -112,7 +112,7 @@ export default function DesignsForm({ labels, access, store, setStore }) {
           parameters: `_recordId=${res?.record?.groupId}`
         })
 
-        changeDT(res2.record)
+        changeDT(res2.record.nraId)
       }
 
       formik.setValues({
@@ -150,7 +150,7 @@ export default function DesignsForm({ labels, access, store, setStore }) {
                     values={formik.values}
                     onChange={(event, newValue) => {
                       formik.setFieldValue('groupId', newValue?.recordId || null)
-                      changeDT(newValue)
+                      changeDT(newValue?.nraId)
                     }}
                     error={formik.touched.groupId && Boolean(formik.errors.groupId)}
                     maxAccess={maxAccess}

--- a/packages/module-purchase/src/pages/pu-vendors/form/VendorsForm.js
+++ b/packages/module-purchase/src/pages/pu-vendors/form/VendorsForm.js
@@ -141,7 +141,7 @@ export default function VendorsForm({ labels, maxAccess: access, recordId, setSt
                 values={formik.values}
                 onChange={(event, newValue) => {
                   formik.setFieldValue('groupId', newValue ? newValue.recordId : '')
-                  changeDT(newValue)
+                  changeDT(newValue?.nraId)
                 }}
                 error={formik.touched.taxId && Boolean(formik.errors.taxId)}
                 maxAccess={maxAccess}

--- a/packages/shared-hooks/src/hooks/useFieldBehaviors.js
+++ b/packages/shared-hooks/src/hooks/useFieldBehaviors.js
@@ -24,7 +24,7 @@ export function useFieldBehavior({ access, fieldName, editMode = true }) {
     refBehavior: query.data,
     maxAccess: query?.data?.maxAccess,
     changeDT(value) {
-      setNraId(value?.nraId)
+      setNraId(value)
     }
   }
 }

--- a/packages/shared-ui/src/components/Inputs/CustomTextField/index.js
+++ b/packages/shared-ui/src/components/Inputs/CustomTextField/index.js
@@ -211,7 +211,7 @@ const CustomTextField = ({
               </IconButton>
             )}
 
-            {(allowClear || (!clearable && !readOnly && (value || value === 0))) && onClear && (
+            {(allowClear || (!clearable && !_readOnly && (value || value === 0))) && onClear && (
               <IconButton
                 className={inputs.iconButton}
                 tabIndex={-1}


### PR DESCRIPTION
MF/designs

the reference field should be editable and mandatory only if
- there is no design group
- the design group is not linked to a number range
- the number range is external

