### PR TITLE
AR-4759 - LIVE

### DIFF
--- a/packages/module-manufacturing/src/pages/damage-return/forms/DamageReturnForm.js
+++ b/packages/module-manufacturing/src/pages/damage-return/forms/DamageReturnForm.js
@@ -52,7 +52,6 @@ export default function DamageReturnForm({ labels, access, recordId }) {
       seqNo: 0,
       pcs: 0,
       workCenterId: null,
-      maxPcs: null,
       type: null,
       damageId: null
     },
@@ -62,15 +61,7 @@ export default function DamageReturnForm({ labels, access, recordId }) {
       jobId: yup.string().required(),
       date: yup.string().required(),
       type: yup.string().required(),
-      pcs: yup.lazy((_, { parent }) =>
-        parent.maxPcs !== null
-          ? yup
-              .number()
-              .min(1)
-              .max(parent.maxPcs, ({ max }) => labels.max + ` ${max}`)
-              .required()
-          : yup.number().min(1).required()
-      ),
+      pcs: yup.number().min(1).required(),
       damageId: yup
         .string()
         .nullable()
@@ -107,8 +98,7 @@ export default function DamageReturnForm({ labels, access, recordId }) {
           sku: jobRes?.record?.sku,
           itemName: jobRes?.record?.itemName,
           designName: jobRes?.record?.designName,
-          designRef: jobRes?.record?.designRef,
-          maxPcs: res?.record?.pcs
+          designRef: jobRes?.record?.designRef
         })
       })
     })
@@ -179,7 +169,7 @@ export default function DamageReturnForm({ labels, access, recordId }) {
                 displayField={['reference', 'name']}
                 values={formik.values}
                 maxAccess={maxAccess}
-                onChange={(event, newValue) => {
+                onChange={(_, newValue) => {
                   formik.setFieldValue('dtId', newValue?.recordId)
                   changeDT(newValue)
                 }}
@@ -211,9 +201,8 @@ export default function DamageReturnForm({ labels, access, recordId }) {
                 valueField='key'
                 displayField='value'
                 maxAccess={maxAccess}
-                onChange={(event, newValue) => {
+                onChange={(_, newValue) => {
                   formik.setFieldValue('type', newValue?.key)
-                  formik.setFieldValue('maxPcs', null)
                 }}
                 error={formik.touched.type && Boolean(formik.errors.type)}
               />
@@ -240,7 +229,7 @@ export default function DamageReturnForm({ labels, access, recordId }) {
                   { key: 'reference', value: 'Reference' },
                   { key: 'jobRef', value: 'Job Order Ref' }
                 ]}
-                onChange={async (event, newValue) => {
+                onChange={async (_, newValue) => {
                   if (newValue) {
                     await getRequest({
                       extension: ManufacturingRepository.MFJobOrder.get,
@@ -259,8 +248,7 @@ export default function DamageReturnForm({ labels, access, recordId }) {
                         workCenterName: newValue?.wcName || '',
                         workCenterId: newValue?.workCenterId || null,
                         plantId: newValue?.plantId || null,
-                        pcs: newValue?.pcs || 0,
-                        maxPcs: newValue?.pcs || 0
+                        pcs: isCancellationOfDamage ? newValue?.damagedPcs : 0
                       })
                     })
                   } else {
@@ -276,8 +264,7 @@ export default function DamageReturnForm({ labels, access, recordId }) {
                       jobRef: '',
                       workCenterName: '',
                       workCenterId: null,
-                      pcs: 0,
-                      maxPcs: null
+                      pcs: 0
                     })
                   }
                 }}
@@ -305,7 +292,7 @@ export default function DamageReturnForm({ labels, access, recordId }) {
                   { key: 'itemName', value: 'Item Name' },
                   { key: 'description', value: 'Description' }
                 ]}
-                onChange={(event, newValue) => {
+                onChange={(_, newValue) => {
                   formik.setValues({
                     ...formik.values,
                     jobId: newValue?.recordId || null,
@@ -316,8 +303,7 @@ export default function DamageReturnForm({ labels, access, recordId }) {
                     itemName: newValue?.itemName || '',
                     workCenterName: newValue?.wcName || '',
                     workCenterId: newValue?.workCenterId || null,
-                    plantId: newValue?.plantId || null,
-                    maxPcs: 32767
+                    plantId: newValue?.plantId || null
                   })
                 }}
                 errorCheck={'jobId'}
@@ -363,7 +349,7 @@ export default function DamageReturnForm({ labels, access, recordId }) {
                 valueField='recordId'
                 displayField={['reference', 'name']}
                 maxAccess={maxAccess}
-                onChange={(event, newValue) => {
+                onChange={(_, newValue) => {
                   formik.setFieldValue('plantId', newValue?.recordId)
                 }}
                 error={formik.touched.plantId && Boolean(formik.errors.plantId)}
@@ -399,14 +385,13 @@ export default function DamageReturnForm({ labels, access, recordId }) {
               <CustomNumberField
                 name='pcs'
                 required
-                readOnly={editMode}
+                readOnly={editMode || isCancellationOfDamage}
                 label={labels.pcs}
                 value={formik.values?.pcs}
                 onChange={formik.handleChange}
                 onClear={() => formik.setFieldValue('pcs', 0)}
                 maxAccess={maxAccess}
                 error={formik.touched.pcs && Boolean(formik.errors.pcs)}
-                helperText={formik.touched.pcs && formik.errors.pcs}
               />
             </Grid>
             <Grid item xs={7}></Grid>


### PR DESCRIPTION
when selection Type Cancellation of Damage, the PCS field should be filled automatically from the Damage selected, and the field PCS should be disabled.
i also removed maxPcs, it was not returned in the backend and it's useless because it was only filled when we have a design