### PR TITLE
AR-4745

### DIFF
--- a/packages/module-manufacturing/src/pages/mf-batch-transfer/Forms/BatchTransferForm.js
+++ b/packages/module-manufacturing/src/pages/mf-batch-transfer/Forms/BatchTransferForm.js
@@ -191,7 +191,7 @@ export default function BatchTransferForm({ labels, maxAccess: access, recordId 
       label: labels.jobOrder,
       name: 'jobRef',
       disableDuplicate: true,
-      flex: 1,
+      flex: 2,
       props: {
         endpointId: ManufacturingRepository.MFJobOrder.snapshot4,
         parameters: {
@@ -204,6 +204,11 @@ export default function BatchTransferForm({ labels, maxAccess: access, recordId 
           { from: 'reference', to: 'jobRef' },
           { from: 'itemName', to: 'itemName' },
           { from: 'itemCategoryName', to: 'itemCategoryName' }
+        ],
+        columnsInDropDown: [
+          { key: 'reference', value: 'Reference' },
+          { key: 'sku', value: 'SKU' },
+          { key: 'designName', value: 'Design Name' },
         ],
         displayFieldWidth: 4,
         readOnly: !formik.values?.header?.fromWCId

--- a/packages/module-manufacturing/src/pages/mf-batch-transfer/index.js
+++ b/packages/module-manufacturing/src/pages/mf-batch-transfer/index.js
@@ -124,7 +124,7 @@ const BatchTransfer = () => {
       },
       width: 1350,
       height: 750,
-      title: labels.batchTransfer
+      title: labels.batchJobTransfer
     })
   }
 


### PR DESCRIPTION
batch job transfer modifications
lookup Job Order, to show also SKU - Design.
Job Order column, make it bigger to show the full reference of the job
when you open the Edit/Add screen, the name should be Batch Job Transfer (instead of Batch Transfer)