### PR TITLE
AR-4764

### DIFF
--- a/packages/module-bt/src/pages/bt-cmp/forms/CommodityPairsForm.js
+++ b/packages/module-bt/src/pages/bt-cmp/forms/CommodityPairsForm.js
@@ -14,10 +14,14 @@ import { useInvalidate } from '@argus/shared-hooks/src/hooks/resource'
 import { ControlContext } from '@argus/shared-providers/src/providers/ControlContext'
 import { BrokerageTradingRepository } from '@argus/repositories/src/repositories/BrokerageTradingRepository'
 import { InventoryRepository } from '@argus/repositories/src/repositories/InventoryRepository'
+import { DefaultsContext } from '@argus/shared-providers/src/providers/DefaultsContext'
 
 export default function CommodityPairsForm({ labels, maxAccess, record, recordId }) {
   const { postRequest } = useContext(RequestsContext)
   const { platformLabels } = useContext(ControlContext)
+  const { systemDefaults } = useContext(DefaultsContext)
+  const msId = parseInt(systemDefaults?.list?.find(obj => obj.key === 'fixing_msId')?.value) || null
+
 
   const invalidate = useInvalidate({
     endpointId: BrokerageTradingRepository.CommodityPair.page
@@ -27,7 +31,9 @@ export default function CommodityPairsForm({ labels, maxAccess, record, recordId
     initialValues: {
       recordId,
       currencyId: null,
-      metalId: null
+      metalId: null,
+      defQtyMUId: null,
+      defUnitPriceMUId: null
     },
     maxAccess,
     validationSchema: yup.object({
@@ -98,6 +104,46 @@ export default function CommodityPairsForm({ labels, maxAccess, record, recordId
                   formik.setFieldValue('metalId', newValue?.recordId || null)
                 }}
                 error={formik.touched.metalId && Boolean(formik.errors.metalId)}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <ResourceComboBox
+                endpointId={msId && InventoryRepository.MeasurementUnit.qry}
+                parameters={msId && `_msId=${msId}`}
+                name='defQtyMUId'
+                label={labels.defQtyMU}
+                valueField='recordId'
+                displayField={['reference', 'name']}
+                columnsInDropDown={[
+                  { key: 'reference', value: 'Reference' },
+                  { key: 'name', value: 'Name' }
+                ]}
+                values={formik.values}
+                maxAccess={maxAccess}
+                onChange={(_, newValue) => {
+                  formik.setFieldValue('defQtyMUId', newValue?.recordId || null)
+                }}
+                error={formik.touched.defQtyMUId && Boolean(formik.errors.defQtyMUId)}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <ResourceComboBox
+                endpointId={msId && InventoryRepository.MeasurementUnit.qry}
+                parameters={msId && `_msId=${msId}`}
+                name='defUnitPriceMUId'
+                label={labels.defUnitPriceMU}
+                valueField='recordId'
+                displayField={['reference', 'name']}
+                columnsInDropDown={[
+                  { key: 'reference', value: 'Reference' },
+                  { key: 'name', value: 'Name' }
+                ]}
+                values={formik.values}
+                maxAccess={maxAccess}
+                onChange={(_, newValue) => {
+                  formik.setFieldValue('defUnitPriceMUId', newValue?.recordId || null)
+                }}
+                error={formik.touched.defUnitPriceMUId && Boolean(formik.errors.defUnitPriceMUId)}
               />
             </Grid>
           </Grid>

--- a/packages/shared-ui/src/components/Shared/Forms/FixingForm.js
+++ b/packages/shared-ui/src/components/Shared/Forms/FixingForm.js
@@ -573,11 +573,16 @@ useEffect(() => {
                       onChange={async (_, newValue) => {
                         const res = await getMetalPurity(newValue?.metalId)
 
+                        setReCalc(true)
                         formik.setValues({
                           ...formik.values,
                           purity: res?.purity ?? null,
                           currencyId: newValue?.currencyId || null,
                           metalId: newValue?.metalId || null,
+                          qty_muId: newValue?.defQtyMUId || null,
+                          qty_muQty: newValue?.defQtyMuQty || null,
+                          unitPrice_muId: newValue?.defUnitPriceMUId || null,
+                          unitPrice_muQty: newValue?.defUnitPriceMUQty || null,
                           currencyId_metalId: newValue ? `${newValue.currencyId}${newValue.metalId}` : null
                         })
                         


### PR DESCRIPTION
add 2 optional combos: default Qty MU and default Unit Price MU
both MU combos filter by the MsId in brokerage/defaults measurement schedule field
these default fields should be filled in the fixing activities when selecting commodity pair 