### PR TITLE
AR-4769

### DIFF
--- a/packages/module-auth/src/pages/repai-request/index.js
+++ b/packages/module-auth/src/pages/repai-request/index.js
@@ -12,6 +12,8 @@ import { Grow } from '@argus/shared-ui/src/components/Layouts/Grow'
 import { ControlContext } from '@argus/shared-providers/src/providers/ControlContext'
 import { RepairAndServiceRepository } from '@argus/repositories/src/repositories/RepairAndServiceRepository'
 import RepairRequestForm from './Forms/RepairRequestForm'
+import { SystemFunction } from '@argus/shared-domain/src/resources/SystemFunction'
+import { useDocumentTypeProxy } from '@argus/shared-hooks/src/hooks/documentReferenceBehaviors'
 
 export default function RepairRequest() {
   const { getRequest, postRequest } = useContext(RequestsContext)
@@ -70,8 +72,13 @@ export default function RepairRequest() {
     }
   ]
 
-  const add = () => {
-    openForm()
+  const { proxyAction } = useDocumentTypeProxy({
+    functionId: SystemFunction.RepairRequest,
+    action: openForm
+  })
+
+  const add = async () => {
+   await proxyAction()
   }
 
   const edit = obj => {

--- a/packages/module-delivery/src/pages/delivery-orders/index.js
+++ b/packages/module-delivery/src/pages/delivery-orders/index.js
@@ -12,6 +12,8 @@ import { ControlContext } from '@argus/shared-providers/src/providers/ControlCon
 import { DeliveryRepository } from '@argus/repositories/src/repositories/DeliveryRepository'
 import RPBGridToolbar from '@argus/shared-ui/src/components/Shared/RPBGridToolbar'
 import DeliveriesOrdersForm from './Forms/DeliveryOrdersForm'
+import { SystemFunction } from '@argus/shared-domain/src/resources/SystemFunction'
+import { useDocumentTypeProxy } from '@argus/shared-hooks/src/hooks/documentReferenceBehaviors'
 
 const DeliveryOrders = () => {
   const { getRequest, postRequest } = useContext(RequestsContext)
@@ -125,8 +127,13 @@ const DeliveryOrders = () => {
     }
   ]
 
-  const add = () => {
-    openForm()
+  const { proxyAction } = useDocumentTypeProxy({
+    functionId: SystemFunction.DeliveryOrder,
+    action: openForm
+  })
+
+  const add = async () => {
+   await proxyAction()
   }
 
   const edit = obj => {

--- a/packages/module-delivery/src/pages/outbound-transportation/index.js
+++ b/packages/module-delivery/src/pages/outbound-transportation/index.js
@@ -14,6 +14,8 @@ import OutboundTranspForm from './forms/OutboundTranspForm'
 import RPBGridToolbar from '@argus/shared-ui/src/components/Shared/RPBGridToolbar'
 import NormalDialog from '@argus/shared-ui/src/components/Shared/NormalDialog'
 import { LockedScreensContext } from '@argus/shared-providers/src/providers/LockedScreensContext'
+import { useDocumentTypeProxy } from '@argus/shared-hooks/src/hooks/documentReferenceBehaviors'
+import { SystemFunction } from '@argus/shared-domain/src/resources/SystemFunction'
 
 const OutboundTransp = () => {
   const { getRequest, postRequest } = useContext(RequestsContext)
@@ -127,8 +129,13 @@ const OutboundTransp = () => {
     }
   ]
 
-  const add = () => {
-    openForm()
+  const { proxyAction } = useDocumentTypeProxy({
+    functionId: SystemFunction.DeliveryTrip,
+    action: openForm
+  })
+
+  const add = async () => {
+   await proxyAction()
   }
 
   const edit = obj => {

--- a/packages/module-fa/src/pages/md-asset-depreciation/index.js
+++ b/packages/module-fa/src/pages/md-asset-depreciation/index.js
@@ -12,12 +12,12 @@ import { ControlContext } from '@argus/shared-providers/src/providers/ControlCon
 import RPBGridToolbar from '@argus/shared-ui/src/components/Shared/RPBGridToolbar'
 import { FixedAssetsRepository } from '@argus/repositories/src/repositories/FixedAssetsRepository'
 import AssetsForm from './form/AssetsForm'
+import { SystemFunction } from '@argus/shared-domain/src/resources/SystemFunction'
+import { useDocumentTypeProxy } from '@argus/shared-hooks/src/hooks/documentReferenceBehaviors'
 
 const AssetsDescription = () => {
   const { getRequest, postRequest } = useContext(RequestsContext)
   const { platformLabels } = useContext(ControlContext)
-  const [params, setParams] = useState('')
-
   const { stack } = useWindow()
 
   async function fetchGridData(options = {}) {
@@ -118,12 +118,17 @@ const AssetsDescription = () => {
     })
   }
 
+  const { proxyAction } = useDocumentTypeProxy({
+    functionId: SystemFunction.AssetsDepreciation,
+    action: openForm
+  })
+
   const edit = obj => {
     openForm(obj?.recordId)
   }
 
-  const add = () => {
-    openForm()
+  const add = async () => {
+   await proxyAction()
   }
 
   const del = async obj => {

--- a/packages/module-financials/src/pages/fi-pv-expenses/index.js
+++ b/packages/module-financials/src/pages/fi-pv-expenses/index.js
@@ -13,6 +13,8 @@ import { FinancialRepository } from '@argus/repositories/src/repositories/Financ
 import FiPaymentVoucherExpensesForm from './forms/PaymentVoucherExpensesForm'
 import RPBGridToolbar from '@argus/shared-ui/src/components/Shared/RPBGridToolbar'
 import { DefaultsContext } from '@argus/shared-providers/src/providers/DefaultsContext'
+import { useDocumentTypeProxy } from '@argus/shared-hooks/src/hooks/documentReferenceBehaviors'
+import { SystemFunction } from '@argus/shared-domain/src/resources/SystemFunction'
 
 const FiPaymentVouchers = () => {
   const { getRequest, postRequest } = useContext(RequestsContext)
@@ -126,8 +128,13 @@ const FiPaymentVouchers = () => {
     }
   ]
 
-  const add = () => {
-    openForm()
+  const { proxyAction } = useDocumentTypeProxy({
+    functionId: SystemFunction.PaymentVoucher,
+    action: openForm
+  })
+
+  const add = async () => {
+   await proxyAction()
   }
 
   const edit = obj => {

--- a/packages/module-manufacturing/src/pages/mf-prod-sheet/index.js
+++ b/packages/module-manufacturing/src/pages/mf-prod-sheet/index.js
@@ -14,6 +14,8 @@ import ProductionSheetForm from './Forms/ProductionSheetForm'
 import { ManufacturingRepository } from '@argus/repositories/src/repositories/ManufacturingRepository'
 import { SystemRepository } from '@argus/repositories/src/repositories/SystemRepository'
 import RPBGridToolbar from '@argus/shared-ui/src/components/Shared/RPBGridToolbar'
+import { SystemFunction } from '@argus/shared-domain/src/resources/SystemFunction'
+import { useDocumentTypeProxy } from '@argus/shared-hooks/src/hooks/documentReferenceBehaviors'
 
 const ProductionSheet = () => {
   const { getRequest, postRequest } = useContext(RequestsContext)
@@ -86,8 +88,13 @@ const ProductionSheet = () => {
     }
   ]
 
-  const add = () => {
-    openForm()
+  const { proxyAction } = useDocumentTypeProxy({
+    functionId: SystemFunction.ProductionSheet,
+    action: openForm
+  })
+
+  const add = async () => {
+   await proxyAction()
   }
 
   const edit = obj => {

--- a/packages/module-purchase/src/pages/shipments/index.js
+++ b/packages/module-purchase/src/pages/shipments/index.js
@@ -12,6 +12,8 @@ import { ControlContext } from '@argus/shared-providers/src/providers/ControlCon
 import { PurchaseRepository } from '@argus/repositories/src/repositories/PurchaseRepository'
 import RPBGridToolbar from '@argus/shared-ui/src/components/Shared/RPBGridToolbar'
 import ShipmentsForm from './forms/ShipmentsForm'
+import { SystemFunction } from '@argus/shared-domain/src/resources/SystemFunction'
+import { useDocumentTypeProxy } from '@argus/shared-hooks/src/hooks/documentReferenceBehaviors'
 
 const Shipments = () => {
   const { getRequest, postRequest } = useContext(RequestsContext)
@@ -97,8 +99,13 @@ const Shipments = () => {
     }
   ]
 
-  const add = () => {
-    openForm()
+  const { proxyAction } = useDocumentTypeProxy({
+    functionId: SystemFunction.Shipment,
+    action: openForm
+  })
+
+  const add = async () => {
+   await proxyAction()
   }
 
   const edit = obj => {


### PR DESCRIPTION
When no active document types & no number range selected in system function the form shouldn't open in new mode.
On deploy it's showing an exception (Assign the system Function to a number range) but also it’s opening the form,
this bug is present in the below pages: 
- Outbound transportation
- Repair request
- Delivery order
- Asset depreciation
- Payment Voucher
- Production sheet
- Shipment

-> The solution is to call proxyAction when opening the popup in the activities 