### PR TITLE
AR-4884

### DIFF
--- a/apps/main/src/pages/mf-open-po/index.js
+++ b/apps/main/src/pages/mf-open-po/index.js
@@ -1,0 +1,1 @@
+export { default } from '@argus/module-manufacturing/src/pages/mf-open-po'

--- a/packages/module-delivery/src/pages/undelivered-items/index.js
+++ b/packages/module-delivery/src/pages/undelivered-items/index.js
@@ -79,7 +79,7 @@ const UndeliveredItems = () => {
 
       if (itemValues?.length < 1) {
         stackError({
-          message: labels.checkItemsBeforeAppend
+          message: platformLabels.checkItemsBeforeAppend
         })
 
         return

--- a/packages/module-inventory/src/pages/ir-gen-con/index.js
+++ b/packages/module-inventory/src/pages/ir-gen-con/index.js
@@ -112,7 +112,7 @@ export default function IRGenerateConsumption() {
     const list = formik.values.items.filter(row => row.isChecked)
     if (list.length < 1) {
       stackError({
-        message: labels.checkItemsBeforeAppend
+        message: platformLabels.checkItemsBeforeAppend
       })
 
       return false

--- a/packages/module-inventory/src/pages/ir-gen-tfr/index.js
+++ b/packages/module-inventory/src/pages/ir-gen-tfr/index.js
@@ -109,7 +109,7 @@ export default function IRGenerateTransfer() {
     const list = formik.values.items.filter(row => row.isChecked)
     if (list.length < 1) {
       stackError({
-        message: labels.checkItemsBeforeAppend
+        message: platformLabels.checkItemsBeforeAppend
       })
 
       return false

--- a/packages/module-manufacturing/src/pages/mf-open-po/index.js
+++ b/packages/module-manufacturing/src/pages/mf-open-po/index.js
@@ -30,27 +30,25 @@ const OpenProductionOrder = () => {
     validateOnChange: true,
     onSubmit: async obj => {
 
-      const itemValues = items
+      const itemValues = obj?.items
         .filter(item => item.isChecked)
-        .map(({ scheduledDate, functionId, id, isChecked, ...item }) => item)
-
+        .map(({ id, isChecked, ...item }) => item)
       if (itemValues?.length < 1) {
         stackError({
-          message: labels.checkItemsBeforeAppend
+          message: platformLabels.checkItemsBeforeAppend
         })
 
         return
       }
 
-      const res = await postRequest({
+      await postRequest({
         extension: ManufacturingRepository.ProductionOrder.generate,
         record: JSON.stringify({ items: itemValues })
       })
 
-      if (res.recordId) {
-        toast.success(platformLabels.Generated)
-        getData()
-      }
+      toast.success(platformLabels.Generated)
+      getData()
+      
     }
   })
 
@@ -90,7 +88,7 @@ const OpenProductionOrder = () => {
           const items = formik.values.items.map(({ isChecked, ...item }) => ({
             ...item,
             isChecked: checked,
-            produceNow: checked ? item.balance : 0
+            producedNow: checked ? item.balance : 0
           }))
 
           formik.setFieldValue('items', items)
@@ -98,7 +96,7 @@ const OpenProductionOrder = () => {
       },
 
       async onChange({ row: { update, newRow } }) {
-        update({ produceNow: newRow.isChecked ? newRow.balance : 0 })
+        update({ producedNow: newRow.isChecked ? newRow.balance : 0 })
       }
     },
     {
@@ -163,21 +161,21 @@ const OpenProductionOrder = () => {
     {
       component: 'numberfield',
       label: labels.genQty,
-      name: 'produceNow',
+      name: 'producedNow',
       updateOn: 'blur',
       defaultValue: 0,
       propsReducer({ row, props }) {
         return { ...props, readOnly: !row.isChecked }
       },
       async onChange({ row: { update, newRow } }) {
-        const { produceNow, balance, qty } = newRow
-        let value = produceNow
+        const { producedNow, balance } = newRow
+        let value = producedNow
         const maxValue = balance
 
         if (value > maxValue) 
         value = maxValue
 
-        update({ produceNow: value || 0 })
+        update({ producedNow: value || 0 })
       }
     }
   ]

--- a/packages/module-manufacturing/src/pages/mf-open-po/index.js
+++ b/packages/module-manufacturing/src/pages/mf-open-po/index.js
@@ -1,0 +1,219 @@
+import { useContext, useEffect } from 'react'
+import toast from 'react-hot-toast'
+import { RequestsContext } from '@argus/shared-providers/src/providers/RequestsContext'
+import { useResourceQuery } from '@argus/shared-hooks/src/hooks/resource'
+import { ResourceIds } from '@argus/shared-domain/src/resources/ResourceIds'
+import { VertLayout } from '@argus/shared-ui/src/components/Layouts/VertLayout'
+import { Grow } from '@argus/shared-ui/src/components/Layouts/Grow'
+import { ControlContext } from '@argus/shared-providers/src/providers/ControlContext'
+import { useForm } from '@argus/shared-hooks/src/hooks/form'
+import { DataGrid } from '@argus/shared-ui/src/components/Shared/DataGrid'
+import { formatDateFromApi } from '@argus/shared-domain/src/lib/date-helper'
+import { useError } from '@argus/shared-providers/src/providers/error'
+import Form from '@argus/shared-ui/src/components/Shared/Form'
+import { ManufacturingRepository } from '@argus/repositories/src/repositories/ManufacturingRepository'
+
+const OpenProductionOrder = () => {
+  const { getRequest, postRequest } = useContext(RequestsContext)
+  const { platformLabels } = useContext(ControlContext)
+  const { stack: stackError } = useError()
+
+  const { labels, access } = useResourceQuery({
+    datasetId: ResourceIds.OpenProductionOrder
+  })
+
+  const { formik } = useForm({
+    maxAccess: access,
+    initialValues: {
+      items: []
+    },
+    validateOnChange: true,
+    onSubmit: async obj => {
+
+      const itemValues = items
+        .filter(item => item.isChecked)
+        .map(({ scheduledDate, functionId, id, isChecked, ...item }) => item)
+
+      if (itemValues?.length < 1) {
+        stackError({
+          message: labels.checkItemsBeforeAppend
+        })
+
+        return
+      }
+
+      const res = await postRequest({
+        extension: ManufacturingRepository.ProductionOrder.generate,
+        record: JSON.stringify({ items: itemValues })
+      })
+
+      if (res.recordId) {
+        toast.success(platformLabels.Generated)
+        getData()
+      }
+    }
+  })
+
+  async function getData() {
+    const result = await getRequest({
+      extension: ManufacturingRepository.ProductionOrder.open,
+      parameters: `_params=`
+    })
+
+    const res = result?.list?.map((item, index) => ({
+      ...item,
+      id: index + 1,
+      date: formatDateFromApi(item.date),
+      balance: item.qty - item.producedQty
+    }))
+
+    formik.setFieldValue('items', res)
+  }
+
+   useEffect(() => {
+      ;(async function () {
+        getData()
+      })()
+    }, [])
+
+  const isCheckedAll = formik.values.items?.length > 0 && formik.values.items?.every(item => item?.isChecked)
+
+  const columns = [
+    {
+      component: 'checkbox',
+      name: 'isChecked',
+      flex: 0.3,
+      checkAll: {
+        value: isCheckedAll,
+        visible: true,
+        onChange({ checked }) {
+          const items = formik.values.items.map(({ isChecked, ...item }) => ({
+            ...item,
+            isChecked: checked,
+            produceNow: checked ? item.balance : 0
+          }))
+
+          formik.setFieldValue('items', items)
+        }
+      },
+
+      async onChange({ row: { update, newRow } }) {
+        update({ produceNow: newRow.isChecked ? newRow.balance : 0 })
+      }
+    },
+    {
+      component: 'image',
+      name: 'pictureUrl',
+      label: labels.image,
+      width: 70,
+      onClick: ({ value, row }) => {
+        stack({
+          Component: ImageViewer,
+          props: {
+            imageUrl: value
+          },
+          width: 800,
+          height: 600,
+          title: row.sku
+        })
+      }
+    },
+    {
+      component: 'textfield',
+      label: labels.poRef,
+      name: 'poRef',
+      props: { readOnly: true }
+    },
+    {
+      component: 'textfield',
+      label: labels.sku,
+      name: 'sku',
+      props: { readOnly: true }
+    },
+    {
+      component: 'textfield',
+      label: labels.name,
+      name: 'itemName',
+      props: { readOnly: true }
+    },
+    {
+      component: 'numberfield',
+      label: labels.itemWeight,
+      name: 'itemWeight',
+      props: { readOnly: true }
+    },
+    {
+      component: 'numberfield',
+      label: labels.qty,
+      name: 'qty',
+      props: { readOnly: true }
+    },
+    {
+      component: 'numberfield',
+      label: labels.produced,
+      name: 'producedQty',
+      props: { readOnly: true }
+    },
+    {
+      component: 'numberfield',
+      label: labels.balance,
+      name: 'balance',
+      props: { readOnly: true, decimalScale: 2 }
+    },
+    {
+      component: 'numberfield',
+      label: labels.genQty,
+      name: 'produceNow',
+      updateOn: 'blur',
+      defaultValue: 0,
+      propsReducer({ row, props }) {
+        return { ...props, readOnly: !row.isChecked }
+      },
+      async onChange({ row: { update, newRow } }) {
+        const { produceNow, balance, qty } = newRow
+        let value = produceNow
+        const maxValue = balance
+
+        if (value > maxValue) 
+        value = maxValue
+
+        update({ produceNow: value || 0 })
+      }
+    }
+  ]
+
+  const actions = [
+    {
+      key: 'generate',
+      condition: true,
+      onClick: () => formik.handleSubmit()
+    }
+  ]
+
+  return (
+    <Form
+      actions={actions}
+      onSave={formik.handleSubmit}
+      isSaved={false}
+      maxAccess={access}
+      fullSize
+    >
+      <VertLayout>
+        <Grow>
+          <DataGrid
+            onChange={value => formik.setFieldValue('items', value)}
+            value={formik.values.items}
+            error={formik.errors.items}
+            columns={columns}
+            name='items'
+            allowDelete={false}
+            allowAddNewLine={false}
+            maxAccess={access}
+          />
+        </Grow>
+      </VertLayout>
+    </Form>
+  )
+}
+
+export default OpenProductionOrder

--- a/packages/module-manufacturing/src/pages/mf-open-po/index.js
+++ b/packages/module-manufacturing/src/pages/mf-open-po/index.js
@@ -12,11 +12,14 @@ import { formatDateFromApi } from '@argus/shared-domain/src/lib/date-helper'
 import { useError } from '@argus/shared-providers/src/providers/error'
 import Form from '@argus/shared-ui/src/components/Shared/Form'
 import { ManufacturingRepository } from '@argus/repositories/src/repositories/ManufacturingRepository'
+import { useWindow } from '@argus/shared-providers/src/providers/windows'
+import ImageViewer from '@argus/shared-ui/src/components/Shared/ImageViewer'
 
 const OpenProductionOrder = () => {
   const { getRequest, postRequest } = useContext(RequestsContext)
   const { platformLabels } = useContext(ControlContext)
   const { stack: stackError } = useError()
+  const { stack } = useWindow()
 
   const { labels, access } = useResourceQuery({
     datasetId: ResourceIds.OpenProductionOrder
@@ -27,7 +30,6 @@ const OpenProductionOrder = () => {
     initialValues: {
       items: []
     },
-    validateOnChange: true,
     onSubmit: async obj => {
 
       const itemValues = obj?.items

--- a/packages/module-manufacturing/src/pages/mf-open-po/index.js
+++ b/packages/module-manufacturing/src/pages/mf-open-po/index.js
@@ -105,7 +105,7 @@ const OpenProductionOrder = () => {
       component: 'image',
       name: 'pictureUrl',
       label: labels.image,
-      width: 70,
+      width: 50,
       onClick: ({ value, row }) => {
         stack({
           Component: ImageViewer,

--- a/packages/module-purchase/src/pages/pu-open-po/index.js
+++ b/packages/module-purchase/src/pages/pu-open-po/index.js
@@ -69,7 +69,7 @@ const OpenPurchaseOrder = () => {
 
       if (itemValues?.length < 1) {
         stackError({
-          message: labels.checkItemsBeforeAppend
+          message: platformLabels.checkItemsBeforeAppend
         })
 
         return

--- a/packages/module-purchase/src/pages/pu-open-pr/index.js
+++ b/packages/module-purchase/src/pages/pu-open-pr/index.js
@@ -38,7 +38,7 @@ const OpenPurchaseRequisition = () => {
   function checkItems(items) {
     if (items?.length < 1) {
       stackError({
-        message: labels.checkItemsBeforeAppend
+        message: platformLabels.checkItemsBeforeAppend
       })
 
       return false

--- a/packages/repositories/src/repositories/ManufacturingRepository.js
+++ b/packages/repositories/src/repositories/ManufacturingRepository.js
@@ -276,7 +276,7 @@ export const ManufacturingRepository = {
     close: service + 'closePO',
     reopen: service + 'reopenPO',
     open: service + 'openPO',
-    generate: service + 'generateßPO',
+    generate: service + 'genORDFromPO',
   },
   BillOfMaterials: {
     get: service + 'getBMA',

--- a/packages/repositories/src/repositories/ManufacturingRepository.js
+++ b/packages/repositories/src/repositories/ManufacturingRepository.js
@@ -275,6 +275,8 @@ export const ManufacturingRepository = {
     gen: service + 'genPO',
     close: service + 'closePO',
     reopen: service + 'reopenPO',
+    open: service + 'openPO',
+    generate: service + 'generateßPO',
   },
   BillOfMaterials: {
     get: service + 'getBMA',

--- a/packages/shared-domain/src/resources/ResourceIds.js
+++ b/packages/shared-domain/src/resources/ResourceIds.js
@@ -641,6 +641,7 @@ export const ResourceIds = {
   Departments: 70104,
   ProductionSummary: 42351,
   ProductionRequest: 42350,
+  OpenProductionOrder: 42352,
   ProductionClassGroups: 42142,
   WorkCenterGroups: 42143,
   ProductionStandardGroups: 42144,

--- a/packages/shared-ui/src/components/Shared/JobOrderPages/JobOrderForm.js
+++ b/packages/shared-ui/src/components/Shared/JobOrderPages/JobOrderForm.js
@@ -89,6 +89,7 @@ export default function JobOrderForm({
     RMCost: 0,
     deliveryDate: null,
     spId: null,
+    poId: null,
     sizeId: null,
     lineId: null,
     itemsPL: null,
@@ -841,7 +842,7 @@ export default function JobOrderForm({
                         label={labels.expectedQty}
                         value={formik.values.expectedQty}
                         required
-                        readOnly={isCancelled || isReleased || isPosted}
+                        readOnly={formik?.values?.poId || isCancelled || isReleased || isPosted}
                         onChange={e => formik.setFieldValue('expectedQty', e.target.value)}
                         onClear={() => formik.setFieldValue('expectedQty', 0)}
                         error={formik.touched.expectedQty && Boolean(formik.errors.expectedQty)}
@@ -853,7 +854,7 @@ export default function JobOrderForm({
                         label={labels.expectedPcs}
                         value={formik.values.expectedPcs}
                         required
-                        readOnly={isCancelled || isReleased || isPosted}
+                        readOnly={formik?.values?.poId || isCancelled || isReleased || isPosted}
                         onChange={e => {
                           formik.setFieldValue('expectedPcs', e.target.value)
                           formik.setFieldValue(


### PR DESCRIPTION
open production order screen
it will show the production orders, it will generate multiple job orders (1 job for each item)
produce now if the qty of the generated job order, it can't exceed the balance

job order qty and pieces field should be readonly if status = draft and the job order was generated from a production order