### PR TITLE
AR-4927

### DIFF
--- a/packages/module-manufacturing/src/pages/mf-gen-prod-order/index.js
+++ b/packages/module-manufacturing/src/pages/mf-gen-prod-order/index.js
@@ -42,7 +42,8 @@ const GeneratePoductionOrder = () => {
             poId: 0,
             seqNo: 0,
             itemId: item.itemId,
-            qty: item.produceNow
+            qty: item.produceNow,
+            pcs: item.pcs
           }))
       }
 
@@ -78,6 +79,12 @@ const GeneratePoductionOrder = () => {
     {
       field: 'soQty',
       headerName: labels.soQty,
+      type: 'number',
+      flex: 1
+    },
+    {
+      field: 'pcs',
+      headerName: labels.pcs,
       type: 'number',
       flex: 1
     },

--- a/packages/module-manufacturing/src/pages/mf-open-po/index.js
+++ b/packages/module-manufacturing/src/pages/mf-open-po/index.js
@@ -90,7 +90,8 @@ const OpenProductionOrder = () => {
           const items = formik.values.items.map(({ isChecked, ...item }) => ({
             ...item,
             isChecked: checked,
-            producedNow: checked ? item.balance : 0
+            producedNow: checked ? item.balance : 0,
+            jobCount: 1
           }))
 
           formik.setFieldValue('items', items)
@@ -98,7 +99,10 @@ const OpenProductionOrder = () => {
       },
 
       async onChange({ row: { update, newRow } }) {
-        update({ producedNow: newRow.isChecked ? newRow.balance : 0 })
+        update({
+          producedNow: newRow.isChecked ? newRow.balance : 0,
+          jobCount: 1
+        })
       }
     },
     {
@@ -150,6 +154,12 @@ const OpenProductionOrder = () => {
     },
     {
       component: 'numberfield',
+      label: labels.pcs,
+      name: 'pcs',
+      props: { readOnly: true }
+    },
+    {
+      component: 'numberfield',
       label: labels.produced,
       name: 'producedQty',
       props: { readOnly: true }
@@ -159,6 +169,19 @@ const OpenProductionOrder = () => {
       label: labels.balance,
       name: 'balance',
       props: { readOnly: true, decimalScale: 2 }
+    },
+    {
+      component: 'numberfield',
+      label: labels.jobCount,
+      name: 'jobCount',
+      updateOn: 'blur',
+      defaultValue: 1,
+      propsReducer({ row, props }) {
+        return { ...props, readOnly: !row.isChecked }
+      },
+      async onChange({ row: { update, newRow } }) {
+       update({ jobCount: Math.max(newRow.jobCount, 1) })
+      }
     },
     {
       component: 'numberfield',

--- a/packages/shared-ui/src/components/Shared/Forms/SalesOrderForm.js
+++ b/packages/shared-ui/src/components/Shared/Forms/SalesOrderForm.js
@@ -142,6 +142,7 @@ const SalesOrderForm = ({ recordId, currency, window }) => {
     initialTdPct: 0,
     baseAmount: 0,
     volume: 0,
+    pieces: 0,
     weight: 0,
     qty: 0,
     serializedAddress: '',
@@ -496,6 +497,15 @@ const SalesOrderForm = ({ recordId, currency, window }) => {
 
         const data = getItemPriceRow(newRow, DIRTYFIELD_QTY)
         update({ ...data, baseQty: newRow?.qty * muQty })
+      }
+    },
+    {
+      component: 'numberfield',
+      label: labels.pcs,
+      name: 'pieces',
+      props: {
+        decimalScale: 2,
+        readOnly: true
       }
     },
     {


### PR DESCRIPTION
1. Sales Order: 
add readonly pcs to the items grid after qty
add it to global auth also to be able to hide it

2. Open Production Order:
add pcs readonly
add job count (editable, default 1 and min value = 1) ***still not added from api side***

3. Generate Production Order:
show only orders that have wip = completed
add pcs column to the itemSummary list readonly
