### PR TITLE
AR-4998 LIVE

### DIFF
--- a/packages/shared-ui/src/components/Shared/Forms/SaleTransactionForm.js
+++ b/packages/shared-ui/src/components/Shared/Forms/SaleTransactionForm.js
@@ -1277,6 +1277,7 @@ export default function SaleTransactionForm({
     const saTrxItems = saTrxPack?.items
     const saTrxTaxes = saTrxPack?.taxes || []
     const balance = saTrxPack?.accountBalance?.balance
+    const creditLimit = saTrxPack?.accountLimit?.limit
     const accountId = saTrxPack?.client?.accountId
     const maxDiscount = saTrxPack?.client?.maxDiscount
     const billAdd = saTrxPack?.formattedAddress
@@ -1339,7 +1340,8 @@ export default function SaleTransactionForm({
           postMetalToFinancials: dtInfo?.record?.postMetalToFinancials,
           maxDiscount: maxDiscount || 0,
           serializedAddress: '',
-          balance
+          balance,
+          creditLimit
         },
         items: modifiedList,
         taxes: saTrxTaxes


### PR DESCRIPTION
credit limit sales invoices
sales invoice screen:

edit this record 191884 , credit limit is empty should read from SA.asmx/get2TR accountLimit object
https://softmachine.atlassian.net/browse/AR-4998