### PR TITLE
OpenPO LIVE - merged

### DIFF
--- a/packages/module-financials/src/pages/fi-payment-vouchers/forms/FiPaymentVouchersForm.js
+++ b/packages/module-financials/src/pages/fi-payment-vouchers/forms/FiPaymentVouchersForm.js
@@ -101,7 +101,7 @@ export default function FiPaymentVouchersForm({ recordId, window }) {
       paymentMethod: yup.string().required(),
       cashAccountId: yup.string().required(),
       checkNo: yup
-        .string()
+        .string().nullable()
         .test(
           'check-no-required-if-payment-method-3',
           'Check number is required when payment method is 3.',


### PR DESCRIPTION
Payment Voucher: check no is required even when payment method is cash