### PR TITLE
Post Work Center Job

### DIFF
--- a/packages/module-manufacturing/src/pages/mf-post-wc-job/index.js
+++ b/packages/module-manufacturing/src/pages/mf-post-wc-job/index.js
@@ -313,7 +313,12 @@ const PostWorkCenterJob = () => {
                   { key: 'workCenterName', value: 'Name' }
                 ]}
                 onChange={async (event, newValue) => {
-                  formik.setFieldValue('workCenterId', newValue?.workCenterId || null)
+                  formik.resetForm({
+                    values: {
+                      ...formik.values,
+                      workCenterId: newValue?.workCenterId || null
+                    }
+                  })
                 }}
                 required
                 maxAccess={maxAccess}
@@ -348,7 +353,12 @@ const PostWorkCenterJob = () => {
                   { key: 'workCenterName', value: 'Name' }
                 ]}
                 onChange={async (event, newValue) => {
-                  formik.setFieldValue('toWorkCenterId', newValue?.workCenterId || null)
+                  formik.resetForm({
+                    values: {
+                      ...formik.values,
+                      toWorkCenterId: newValue?.workCenterId || null
+                    }
+                  })
                 }}
                 required={formik.values.routingId}
                 maxAccess={maxAccess}


### PR DESCRIPTION
post work center job (unsaved changes bug)
the issue was when work center or to work center are editable onChange it should update the resetForm 