### PR TITLE
AR-4997

### DIFF
--- a/packages/shared-ui/src/components/Shared/Forms/SaleTransactionForm.js
+++ b/packages/shared-ui/src/components/Shared/Forms/SaleTransactionForm.js
@@ -507,7 +507,7 @@ export default function SaleTransactionForm({
       metalId,
       metalPurity,
       metalRef: itemPhysProp?.metalRef || '',
-      volume: itemPhysProp?.volume || 0,
+      volume: roundTo(itemPhysProp?.volume, 3) || 0,
       weight,
       basePrice: isMetal === false ? ItemConvertPrice?.basePrice || 0 : metalPurity > 0 ? basePriceValue : 0,
       baseLaborPrice,
@@ -798,7 +798,7 @@ export default function SaleTransactionForm({
       label: labels.volume,
       name: 'volume',
       props: {
-        decimalScale: 2,
+        decimalScale: 3,
         readOnly: true
       }
     },
@@ -1692,7 +1692,7 @@ export default function SaleTransactionForm({
       upo: item.upo || 0,
       vatAmount: item.vatAmount || 0,
       weight: item.weight || 0,
-      volume: item.volume || 0,
+      volume: roundTo(item.volume, 3) || 0,
       extendedPrice: item.extendedPrice || 0
     }))
 


### PR DESCRIPTION
sales invoice - unsaved changes
The issue was in the datagrid volume is rounded to 2 digits but it should be 3 digits 
(this was causing an unsaved changes because of the calculation of footer volume because the volume in datagrid is two digits) I asked hasan it is 3 digits for both
https://softmachine.atlassian.net/browse/AR-4997?focusedCommentId=52678 try on CIPA-deploy 