### PR TITLE
AR-5033 LIVE - merged

### DIFF
--- a/packages/shared-ui/src/components/Shared/PurchaseTransactionForm.js
+++ b/packages/shared-ui/src/components/Shared/PurchaseTransactionForm.js
@@ -604,8 +604,7 @@ export default function PurchaseTransactionForm({ recordId, functionId, window }
     {
       component: 'numberfield',
       label: labels.pcs,
-      name: 'pieces',
-      updateOn: 'blur'
+      name: 'pieces'
     },
     {
       component: 'numberfield',


### PR DESCRIPTION
pieces field - purchase return on save it is being sent as null because of the update on blur and we don't need updateOn: 'blur' because pieces is not affecting any field and not being affected 

https://softmachine.atlassian.net/browse/AR-5033
